### PR TITLE
don't copy .git path to recipe meta to avoid configuration errors

### DIFF
--- a/stackinator/builder.py
+++ b/stackinator/builder.py
@@ -240,4 +240,4 @@ class Builder:
         meta_recipe_path.mkdir(exist_ok=True)
         if meta_recipe_path.exists():
             shutil.rmtree(meta_recipe_path)
-        shutil.copytree(recipe.path, meta_recipe_path)
+        shutil.copytree(recipe.path, meta_recipe_path, ignore=shutil.ignore_patterns('.git'))


### PR DESCRIPTION
Fixes intermittent configuration errors when copying the contents of
a `.git` path inside a recipe (if present) to the meta data in the image.