### PR TITLE
Format with black and isort

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,25 @@
+name: lint
+
+on:
+  pull_request:
+    branches: [master, main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - name: Install Tools
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install black flake8 isort mypy
+    - name: Black
+      run: |
+        black .
+    - name: isort
+      run: |
+        isort .

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,3 @@
+[settings]
+ profile = black
+ skip = external/

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,3 +1,0 @@
-[settings]
- profile = black
- skip = external/

--- a/bin/stack-config
+++ b/bin/stack-config
@@ -4,7 +4,6 @@
 import pathlib
 import sys
 
-
 prefix = pathlib.Path(__file__).parent.parent.resolve()
 external = prefix / 'external'
 sys.path = [prefix.as_posix(), external.as_posix()] + sys.path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.isort]
+ profile = "black"
+ skip = ["external/"]

--- a/stackinator/__init__.py
+++ b/stackinator/__init__.py
@@ -1,8 +1,7 @@
 import logging
 import re
 
+VERSION = "1.1-dev0"
+root_logger = logging.getLogger("stackinator")
 
-VERSION = '1.1-dev0'
-root_logger = logging.getLogger('stackinator')
-
-stackinator_version_info = tuple(re.split(r'\.|-', VERSION))
+stackinator_version_info = tuple(re.split(r"\.|-", VERSION))

--- a/stackinator/builder.py
+++ b/stackinator/builder.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 import json
 import logging
 import os
@@ -7,121 +6,131 @@ import platform
 import shutil
 import subprocess
 import sys
+from datetime import datetime
 
 import jinja2
 import yaml
 
-from . import root_logger
-from . import VERSION 
+from . import VERSION, root_logger
 
 
 class Builder:
     def __init__(self, args):
-        self._logger = root_logger 
+        self._logger = root_logger
         path = pathlib.Path(args.build)
         if not path.is_absolute():
             path = pathlib.Path.cwd() / path
 
         if path.exists():
             if not path.is_dir():
-                raise IOError('build path is not a directory')
+                raise IOError("build path is not a directory")
 
         self.path = path
         self.root = prefix = pathlib.Path(__file__).parent.resolve()
 
     def generate(self, recipe):
         # make the paths
-        store_path = self.path / 'store'
-        tmp_path = self.path / 'tmp'
+        store_path = self.path / "store"
+        tmp_path = self.path / "tmp"
 
         self.path.mkdir(exist_ok=True, parents=True)
         store_path.mkdir(exist_ok=True)
         tmp_path.mkdir(exist_ok=True)
 
         # check out the version of spack
-        spack = recipe.config['spack']
-        spack_path = self.path / 'spack'
+        spack = recipe.config["spack"]
+        spack_path = self.path / "spack"
 
         # generate configuration meta data
         meta = {}
-        meta['time'] = datetime.now().strftime("%Y%m%d %H:%M:%S")
+        meta["time"] = datetime.now().strftime("%Y%m%d %H:%M:%S")
         host_data = platform.uname()
-        meta['host'] = {
-                'machine': host_data.machine,
-                'node': host_data.node,
-                'processor': host_data.processor,
-                'release': host_data.release,
-                'system': host_data.system,
-                'version': host_data.version
+        meta["host"] = {
+            "machine": host_data.machine,
+            "node": host_data.node,
+            "processor": host_data.processor,
+            "release": host_data.release,
+            "system": host_data.system,
+            "version": host_data.version,
         }
-        meta['cluster'] = os.getenv('CLUSTER_NAME', default='unknown')
-        meta['stackinator'] = {
-                'version': VERSION,
-                'args': sys.argv,
-                'python': sys.executable
+        meta["cluster"] = os.getenv("CLUSTER_NAME", default="unknown")
+        meta["stackinator"] = {
+            "version": VERSION,
+            "args": sys.argv,
+            "python": sys.executable,
         }
-        meta['spack'] = recipe.config['spack']
+        meta["spack"] = recipe.config["spack"]
         self.meta = meta
 
         # Clone the spack repository if it has not already been checked out
-        if not (spack_path / '.git').is_dir():
+        if not (spack_path / ".git").is_dir():
             self._logger.info(f'spack: clone repository {spack["repo"]}')
 
             # clone the repository
             capture = subprocess.run(
-                ["git", "clone", spack['repo'], spack_path],
+                ["git", "clone", spack["repo"], spack_path],
                 shell=False,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT)
-            self._logger.debug(capture.stdout.decode('utf-8'))
+                stderr=subprocess.STDOUT,
+            )
+            self._logger.debug(capture.stdout.decode("utf-8"))
 
             if capture.returncode != 0:
                 self._logger.debug(f'error cloning the repository {spack["repo"]}')
                 capture.check_returncode()
 
         # Check out a branch or commit if one was specified
-        if spack['commit']:
+        if spack["commit"]:
             self._logger.info(f'spack: checkout branch/commit {spack["commit"]}')
             capture = subprocess.run(
-                ["git", "-C", spack_path, "checkout", spack['commit']],
+                ["git", "-C", spack_path, "checkout", spack["commit"]],
                 shell=False,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT)
-            self._logger.debug(capture.stdout.decode('utf-8'))
+                stderr=subprocess.STDOUT,
+            )
+            self._logger.debug(capture.stdout.decode("utf-8"))
 
             if capture.returncode != 0:
                 self._logger.debug(
-                    f'unable to change to the requested commit {spack["commit"]}')
+                    f'unable to change to the requested commit {spack["commit"]}'
+                )
                 capture.check_returncode()
 
         # load the jinja templating environment
-        template_path = self.root / 'templates'
+        template_path = self.root / "templates"
         env = jinja2.Environment(
-            loader = jinja2.FileSystemLoader(template_path),
-            trim_blocks=True, lstrip_blocks=True)
+            loader=jinja2.FileSystemLoader(template_path),
+            trim_blocks=True,
+            lstrip_blocks=True,
+        )
 
         # generate top level makefiles
-        makefile_template = env.get_template('Makefile')
-        with (self.path / 'Makefile').open('w') as f:
-            cache = {'key': recipe.mirror.key, 'enabled': recipe.mirror.source}
-            f.write(makefile_template.render(
-                cache=cache, modules=recipe.config['modules'], verbose=False))
-            f.write('\n')
+        makefile_template = env.get_template("Makefile")
+        with (self.path / "Makefile").open("w") as f:
+            cache = {"key": recipe.mirror.key, "enabled": recipe.mirror.source}
+            f.write(
+                makefile_template.render(
+                    cache=cache, modules=recipe.config["modules"], verbose=False
+                )
+            )
+            f.write("\n")
 
-        make_user_template = env.get_template('Make.user')
-        with (self.path / 'Make.user').open('w') as f:
-            f.write(make_user_template.render(
-                build_path=self.path, store=recipe.config['store'],
-                verbose=False))
-            f.write('\n')
+        make_user_template = env.get_template("Make.user")
+        with (self.path / "Make.user").open("w") as f:
+            f.write(
+                make_user_template.render(
+                    build_path=self.path, store=recipe.config["store"], verbose=False
+                )
+            )
+            f.write("\n")
 
-        etc_path = self.root / 'etc'
-        for f in ['Make.inc', 'bwrap-mutable-root.sh']:
+        etc_path = self.root / "etc"
+        for f in ["Make.inc", "bwrap-mutable-root.sh"]:
             shutil.copy2(etc_path / f, self.path / f)
 
         # Generate the system configuration: the compilers, environments,
         # mirrors etc. that are defined for the target cluster.
-        config_path = self.path / 'config'
+        config_path = self.path / "config"
         config_path.mkdir(exist_ok=True)
         system_configs_path = pathlib.Path(recipe.configs_path)
 
@@ -130,7 +139,7 @@ class Builder:
             # skip copying mirrors.yaml - this is done in the next step only if
             # mirrors have been enabled and the recipe did not provide a mirror
             # configuration
-            if f.name in ['mirrors.yaml']:
+            if f.name in ["mirrors.yaml"]:
                 continue
 
             # construct full file path
@@ -142,21 +151,21 @@ class Builder:
 
         # copy the optional mirrors.yaml file
         if recipe.mirror.source:
-            dst = config_path / 'mirrors.yaml'
+            dst = config_path / "mirrors.yaml"
             shutil.copy(recipe.mirror.source, dst)
 
         # append recipe packages to packages.yaml
         if recipe.packages:
-            system_packages = system_configs_path / 'packages.yaml'
+            system_packages = system_configs_path / "packages.yaml"
             packages_data = {}
             if system_packages.is_file():
                 # load system yaml
                 with system_packages.open() as fid:
                     raw = yaml.load(fid, Loader=yaml.Loader)
-                    packages_data = raw['packages']
-            packages_data.update(recipe.packages['packages'])
-            packages_yaml = yaml.dump({'packages': packages_data})
-            packages_path = config_path / 'packages.yaml'
+                    packages_data = raw["packages"]
+            packages_data.update(recipe.packages["packages"])
+            packages_yaml = yaml.dump({"packages": packages_data})
+            packages_path = config_path / "packages.yaml"
             with packages_path.open("w") as fid:
                 fid.write(packages_yaml)
 
@@ -164,80 +173,88 @@ class Builder:
         # Step 1: copy the CSCS repo to store_path where, it will be used to
         #         build the stack, and then be part of the upstream provided
         #         to users of the stack.
-        repo_src = self.root / 'repo'
-        repo_dst = store_path / 'repo'
+        repo_src = self.root / "repo"
+        repo_dst = store_path / "repo"
         if repo_dst.exists():
             shutil.rmtree(repo_dst)
 
         shutil.copytree(repo_src, repo_dst)
 
         # Step 2: Create a repos.yaml file in build_path/config
-        repos_yaml_template = env.get_template('repos.yaml')
-        with (config_path / 'repos.yaml').open('w') as f:
-            repo_path = pathlib.Path(recipe.config['store']) / 'repo'
-            f.write(repos_yaml_template.render(
-                repo_path=repo_path.as_posix(),verbose=False))
-            f.write('\n')
+        repos_yaml_template = env.get_template("repos.yaml")
+        with (config_path / "repos.yaml").open("w") as f:
+            repo_path = pathlib.Path(recipe.config["store"]) / "repo"
+            f.write(
+                repos_yaml_template.render(
+                    repo_path=repo_path.as_posix(), verbose=False
+                )
+            )
+            f.write("\n")
 
         # Generate the makefile and spack.yaml files that describe the compilers
         compilers = recipe.generate_compilers()
-        compiler_path = self.path / 'compilers'
+        compiler_path = self.path / "compilers"
         compiler_path.mkdir(exist_ok=True)
-        with (compiler_path / 'Makefile').open(mode='w') as f:
-            f.write(compilers['makefile'])
+        with (compiler_path / "Makefile").open(mode="w") as f:
+            f.write(compilers["makefile"])
 
-        for name, yml in compilers['config'].items():
+        for name, yml in compilers["config"].items():
             compiler_config_path = compiler_path / name
             compiler_config_path.mkdir(exist_ok=True)
-            with (compiler_config_path / 'spack.yaml').open(mode='w') as f:
+            with (compiler_config_path / "spack.yaml").open(mode="w") as f:
                 f.write(yml)
 
         # generate the makefile and spack.yaml files that describe the environments
         environments = recipe.generate_environments()
-        environments_path = self.path / 'environments'
+        environments_path = self.path / "environments"
         os.makedirs(environments_path, exist_ok=True)
-        with (environments_path / 'Makefile').open(mode='w') as f:
-            f.write(environments['makefile'])
+        with (environments_path / "Makefile").open(mode="w") as f:
+            f.write(environments["makefile"])
 
-        for name, yml in environments['config'].items():
+        for name, yml in environments["config"].items():
             env_config_path = environments_path / name
             env_config_path.mkdir(exist_ok=True)
-            with (env_config_path / 'spack.yaml').open(mode='w') as f:
+            with (env_config_path / "spack.yaml").open(mode="w") as f:
                 f.write(yml)
 
         # generate the makefile that generates the configuration for the spack
         # installation
-        make_config_template = env.get_template('Makefile.generate-config')
-        generate_config_path = self.path / 'generate-config'
+        make_config_template = env.get_template("Makefile.generate-config")
+        generate_config_path = self.path / "generate-config"
         generate_config_path.mkdir(exist_ok=True)
 
         # write the Makefile
-        all_compilers=[x for x in recipe.compilers.keys()]
-        release_compilers=[x for x in all_compilers if x != "bootstrap"]
-        with (generate_config_path / 'Makefile').open('w') as f:
-            f.write(make_config_template.render(
-                build_path=self.path.as_posix(),
-                all_compilers=all_compilers,
-                release_compilers=release_compilers,
-                verbose=False))
+        all_compilers = [x for x in recipe.compilers.keys()]
+        release_compilers = [x for x in all_compilers if x != "bootstrap"]
+        with (generate_config_path / "Makefile").open("w") as f:
+            f.write(
+                make_config_template.render(
+                    build_path=self.path.as_posix(),
+                    all_compilers=all_compilers,
+                    release_compilers=release_compilers,
+                    verbose=False,
+                )
+            )
 
         # write the modules.yaml file
-        modules_yaml=recipe.generate_modules()
-        generate_modules_path = self.path / 'modules'
+        modules_yaml = recipe.generate_modules()
+        generate_modules_path = self.path / "modules"
         generate_modules_path.mkdir(exist_ok=True)
-        with (generate_modules_path / 'modules.yaml').open('w') as f:
+        with (generate_modules_path / "modules.yaml").open("w") as f:
             f.write(modules_yaml)
 
         # write the meta data
-        meta_path = self.path / 'store/meta'
+        meta_path = self.path / "store/meta"
         meta_path.mkdir(exist_ok=True)
         # write a json file with basic meta data
-        with (meta_path / 'configure.json').open('w') as f:
+        with (meta_path / "configure.json").open("w") as f:
             f.write(json.dumps(self.meta, sort_keys=True, indent=2))
-            f.write('\n')
+            f.write("\n")
         # copy the recipe to a recipe subdirectory of the meta path
-        meta_recipe_path = meta_path / 'recipe'
+        meta_recipe_path = meta_path / "recipe"
         meta_recipe_path.mkdir(exist_ok=True)
         if meta_recipe_path.exists():
             shutil.rmtree(meta_recipe_path)
-        shutil.copytree(recipe.path, meta_recipe_path, ignore=shutil.ignore_patterns('.git'))
+        shutil.copytree(
+            recipe.path, meta_recipe_path, ignore=shutil.ignore_patterns(".git")
+        )

--- a/stackinator/main.py
+++ b/stackinator/main.py
@@ -7,13 +7,13 @@ import sys
 import time
 import traceback
 
-from . import root_logger, VERSION
+from . import VERSION, root_logger
 from .builder import Builder
 from .recipe import Recipe
 
 
-def generate_logfile_name(name=''):
-    idstr = f'{time.localtime()}{os.getpid}{platform.uname()}'
+def generate_logfile_name(name=""):
+    idstr = f"{time.localtime()}{os.getpid}{platform.uname()}"
     return f'log{name}_{hashlib.md5(idstr.encode("utf-8")).hexdigest()}'
 
 
@@ -23,46 +23,47 @@ def configure_logging(logfile):
     # create stdout handler and set level to info
     ch = logging.StreamHandler(stream=sys.stdout)
     ch.setLevel(logging.INFO)
-    ch.setFormatter(logging.Formatter('%(message)s'))
+    ch.setFormatter(logging.Formatter("%(message)s"))
     root_logger.addHandler(ch)
 
     # create log file handler and set level to debug
-    fh = logging.FileHandler(logfile) #, mode='w')
+    fh = logging.FileHandler(logfile)  # , mode='w')
     fh.setLevel(logging.DEBUG)
-    fh.setFormatter(
-        logging.Formatter('%(asctime)s : %(levelname)-7s : %(message)s'))
+    fh.setFormatter(logging.Formatter("%(asctime)s : %(levelname)-7s : %(message)s"))
     root_logger.addHandler(fh)
 
 
 def log_header(args):
-    root_logger.info('Stackinator')
-    root_logger.info(f'  recipe path: {args.recipe}')
-    root_logger.info(f'  build path : {args.build}')
-    root_logger.info(f'  system     : {args.system}')
+    root_logger.info("Stackinator")
+    root_logger.info(f"  recipe path: {args.recipe}")
+    root_logger.info(f"  build path : {args.build}")
+    root_logger.info(f"  system     : {args.system}")
 
 
 def make_argparser():
     parser = argparse.ArgumentParser(
-        description=('Generate a build configuration for a spack stack from '
-                     'a recipe.')
+        description=(
+            "Generate a build configuration for a spack stack from " "a recipe."
+        )
     )
-    parser.add_argument('--version', action='version',
-                        version=f'stackinator version {VERSION}')
-    parser.add_argument('-b', '--build', required=True, type=str)
-    parser.add_argument('-r', '--recipe', required=True, type=str)
-    parser.add_argument('-s', '--system', required=False, type=str)
-    parser.add_argument('-d', '--debug', action='store_true')
+    parser.add_argument(
+        "--version", action="version", version=f"stackinator version {VERSION}"
+    )
+    parser.add_argument("-b", "--build", required=True, type=str)
+    parser.add_argument("-r", "--recipe", required=True, type=str)
+    parser.add_argument("-s", "--system", required=False, type=str)
+    parser.add_argument("-d", "--debug", action="store_true")
     return parser
 
 
 def main():
-    logfile = generate_logfile_name('_config')
+    logfile = generate_logfile_name("_config")
     configure_logging(logfile)
 
     try:
         parser = make_argparser()
         args = parser.parse_args()
-        root_logger.debug(f'Command line arguments: {args}')
+        root_logger.debug(f"Command line arguments: {args}")
         log_header(args)
 
         recipe = Recipe(args)
@@ -71,15 +72,16 @@ def main():
         builder.generate(recipe)
 
         root_logger.info(
-            '\nConfiguration finished, run the following to build the '
-            'environment:\n'
+            "\nConfiguration finished, run the following to build the " "environment:\n"
         )
-        root_logger.info(f'cd {builder.path}')
-        root_logger.info('env --ignore-environment PATH=/usr/bin:/bin:`pwd`'
-                    '/spack/bin make store.squashfs -j32')
+        root_logger.info(f"cd {builder.path}")
+        root_logger.info(
+            "env --ignore-environment PATH=/usr/bin:/bin:`pwd`"
+            "/spack/bin make store.squashfs -j32"
+        )
         return 0
     except Exception as e:
         root_logger.debug(traceback.format_exc())
         root_logger.error(str(e))
-        root_logger.info(f'see {logfile} for more information')
+        root_logger.info(f"see {logfile} for more information")
         return 1

--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -1,20 +1,19 @@
-import pathlib
 import logging
+import pathlib
 
 import jinja2
 import yaml
 
-from . import schema
-from . import root_logger
+from . import root_logger, schema
 
 
 class Mirror:
     def __init__(self, config, source):
         if config:
-            enabled = config.get('enable', True)
-            key = config.get('key', None)
+            enabled = config.get("enable", True)
+            key = config.get("key", None)
             self._source = None if not enabled else source
-            self._key  = key
+            self._key = key
         else:
             self._source = self._key = None
 
@@ -29,17 +28,17 @@ class Mirror:
 
 class Recipe:
     valid_mpi_specs = {
-        "cray-mpich":  (None, None),
-        "mpich":  ("4.1", "device=ch4 netmod=ofi +slurm"),
+        "cray-mpich": (None, None),
+        "mpich": ("4.1", "device=ch4 netmod=ofi +slurm"),
         "mvapich2": (
-            "3.0a", 
-            "+xpmem fabrics=ch4ofi ch4_max_vcis=4 process_managers=slurm"
-        )
+            "3.0a",
+            "+xpmem fabrics=ch4ofi ch4_max_vcis=4 process_managers=slurm",
+        ),
     }
 
     def __init__(self, args):
         self._logger = root_logger
-        self._logger.debug('Generating recipe')
+        self._logger.debug("Generating recipe")
         path = pathlib.Path(args.recipe)
         if not path.is_absolute():
             path = pathlib.Path.cwd() / path
@@ -50,31 +49,33 @@ class Recipe:
         self.path = path
         self.root = prefix = pathlib.Path(__file__).parent.resolve()
 
-
         # required compiler.yaml file
-        compiler_path = path / 'compilers.yaml'
-        self._logger.debug(f'opening {compiler_path}')
+        compiler_path = path / "compilers.yaml"
+        self._logger.debug(f"opening {compiler_path}")
         if not compiler_path.is_file():
-            raise FileNotFoundError(f"The recipe path '{compiler_path}' does "
-                                    f"not contain compilers.yaml")
+            raise FileNotFoundError(
+                f"The recipe path '{compiler_path}' does " f"not contain compilers.yaml"
+            )
 
         with compiler_path.open() as fid:
             raw = yaml.load(fid, Loader=yaml.Loader)
-            if 'compilers' in raw:
+            if "compilers" in raw:
                 self._logger.warning(
                     f"{compiler_path} uses deprecated 'compilers:' "
                     f"header. This will be an error in future releases."
                 )
-                raw = raw['compilers']
+                raw = raw["compilers"]
             schema.compilers_validator.validate(raw)
             self.generate_compiler_specs(raw)
 
         # required environments.yaml file
-        environments_path = path / 'environments.yaml'
-        self._logger.debug(f'opening {environments_path}')
+        environments_path = path / "environments.yaml"
+        self._logger.debug(f"opening {environments_path}")
         if not environments_path.is_file():
-            raise FileNotFoundError(f"The recipe path '{environments_path}' does "
-                                    f" not contain environments.yaml")
+            raise FileNotFoundError(
+                f"The recipe path '{environments_path}' does "
+                f" not contain environments.yaml"
+            )
 
         with environments_path.open() as fid:
             raw = yaml.load(fid, Loader=yaml.Loader)
@@ -82,11 +83,12 @@ class Recipe:
             self.generate_environment_specs(raw)
 
         # required config.yaml file
-        config_path = path / 'config.yaml'
-        self._logger.debug(f'opening {config_path}')
+        config_path = path / "config.yaml"
+        self._logger.debug(f"opening {config_path}")
         if not config_path.is_file():
-            raise FileNotFoundError(f"The recipe path '{config_path}' does "
-                                    f"not contain compilers.yaml")
+            raise FileNotFoundError(
+                f"The recipe path '{config_path}' does " f"not contain compilers.yaml"
+            )
 
         with config_path.open() as fid:
             raw = yaml.load(fid, Loader=yaml.Loader)
@@ -95,24 +97,26 @@ class Recipe:
 
         # override the system target
         if args.system:
-            self.config['system'] = args.system
+            self.config["system"] = args.system
 
         # optional modules.yaml file
-        modules_path = path / 'modules.yaml'
-        self._logger.debug(f'opening {modules_path}')
+        modules_path = path / "modules.yaml"
+        self._logger.debug(f"opening {modules_path}")
         if not modules_path.is_file():
-            modules_path = (pathlib.Path(args.build) / 
-                'spack/etc/spack/defaults/modules.yaml')
-            self._logger.debug(
-                f'no modules.yaml provided - using the {modules_path}')
+            modules_path = (
+                pathlib.Path(args.build) / "spack/etc/spack/defaults/modules.yaml"
+            )
+            self._logger.debug(f"no modules.yaml provided - using the {modules_path}")
 
         self.modules = modules_path
         if not self.configs_path.is_dir():
-            raise FileNotFoundError(f"The system {self.config['system']!r} is not a supported cluster")
+            raise FileNotFoundError(
+                f"The system {self.config['system']!r} is not a supported cluster"
+            )
 
         # optional packages.yaml file
-        packages_path = path / 'packages.yaml'
-        self._logger.debug(f'opening {packages_path}')
+        packages_path = path / "packages.yaml"
+        self._logger.debug(f"opening {packages_path}")
         self.packages = None
         if packages_path.is_file():
             with packages_path.open() as fid:
@@ -120,14 +124,13 @@ class Recipe:
 
         # Select location of the mirrors.yaml file to use.
         # Look first in the recipe path, then in the system configuration path.
-        mirrors_path = path / 'mirrors.yaml'
+        mirrors_path = path / "mirrors.yaml"
         mirrors_source = mirrors_path if mirrors_path.is_file() else None
         if mirrors_source == None:
-            mirrors_path = self.configs_path / 'mirrors.yaml'
+            mirrors_path = self.configs_path / "mirrors.yaml"
             mirrors_source = mirrors_path if mirrors_path.is_file() else None
 
-        self._mirror = Mirror(config=self.config['mirror'],
-                              source=mirrors_source)
+        self._mirror = Mirror(config=self.config["mirror"], source=mirrors_source)
 
     @property
     def mirror(self):
@@ -136,8 +139,9 @@ class Recipe:
     def generate_modules(self):
         with self.modules.open() as fid:
             raw = yaml.load(fid, Loader=yaml.Loader)
-            raw['modules']['default']['roots']['tcl'] = (
-                pathlib.Path(self.config['store']) / 'modules').as_posix()
+            raw["modules"]["default"]["roots"]["tcl"] = (
+                pathlib.Path(self.config["store"]) / "modules"
+            ).as_posix()
             return yaml.dump(raw)
 
     # creates the self.environments field that describes the full specifications
@@ -151,7 +155,7 @@ class Recipe:
             if ("specs" not in config) or (config["specs"] == None):
                 environments[name]["specs"] = []
 
-            if ("mpi" not in config):
+            if "mpi" not in config:
                 environments[name]["mpi"] = {"spec": None, "gpu": None}
 
         for name, config in environments.items():
@@ -161,8 +165,7 @@ class Recipe:
                 mpi_gpu = mpi["gpu"]
                 if mpi_spec:
                     try:
-                        mpi_impl, mpi_ver = mpi_spec.strip().split(
-                            sep='@', maxsplit=1)
+                        mpi_impl, mpi_ver = mpi_spec.strip().split(sep="@", maxsplit=1)
                     except ValueError:
                         mpi_impl = mpi_spec.strip()
                         mpi_ver = None
@@ -170,14 +173,14 @@ class Recipe:
                     if mpi_impl in Recipe.valid_mpi_specs:
                         default_ver, options = Recipe.valid_mpi_specs[mpi_impl]
                         if mpi_ver:
-                            version_opt = f"@{mpi_ver}" 
+                            version_opt = f"@{mpi_ver}"
                         else:
                             version_opt = f"@{default_ver}" if default_ver else ""
 
                         spec = f"{mpi_impl}{version_opt} {options or ''}".strip()
 
                         if mpi_gpu:
-                            if mpi_impl != 'cray-mpich':
+                            if mpi_impl != "cray-mpich":
                                 spec = f"{spec} cuda_arch=80"
                             else:
                                 spec = f"{spec} +{mpi_gpu}"
@@ -185,10 +188,9 @@ class Recipe:
                         environments[name]["specs"].append(spec)
                     else:
                         # TODO: Create a custom exception type
-                        raise Exception(f'Unsupported mpi: {mpi_impl}')
+                        raise Exception(f"Unsupported mpi: {mpi_impl}")
 
         self.environments = environments
-
 
     # creates the self.compilers field that describes the full specifications
     # for all of teh compilers from the raw compilers.yaml input
@@ -196,35 +198,55 @@ class Recipe:
         compilers = {}
 
         bootstrap = {}
-        bootstrap["packages"]= {
-            "external": ["perl", "m4", "autoconf", "automake", "libtool", 
-                         "gawk", "python", "texinfo", "gawk"],
+        bootstrap["packages"] = {
+            "external": [
+                "perl",
+                "m4",
+                "autoconf",
+                "automake",
+                "libtool",
+                "gawk",
+                "python",
+                "texinfo",
+                "gawk",
+            ],
             "variants": {
                 "gcc": "[build_type=Release ~bootstrap +strip]",
                 "mpc": "[libs=static]",
                 "gmp": "[libs=static]",
                 "mpfr": "[libs=static]",
                 "zstd": "[libs=static]",
-                "zlib": "[~shared]"
-            }
+                "zlib": "[~shared]",
+            },
         }
         bootstrap_spec = raw["bootstrap"]["spec"]
-        bootstrap["specs"] = [f"{bootstrap_spec} languages=c,c++",
-                              f"squashfs default_compression=zstd"]
+        bootstrap["specs"] = [
+            f"{bootstrap_spec} languages=c,c++",
+            f"squashfs default_compression=zstd",
+        ]
         compilers["bootstrap"] = bootstrap
 
         gcc = {}
         gcc["packages"] = {
-            "external": ["perl", "m4", "autoconf", "automake", "libtool",
-                         "gawk", "python", "texinfo", "gawk"],
+            "external": [
+                "perl",
+                "m4",
+                "autoconf",
+                "automake",
+                "libtool",
+                "gawk",
+                "python",
+                "texinfo",
+                "gawk",
+            ],
             "variants": {
                 "gcc": "[build_type=Release +profiled +strip]",
                 "mpc": "[libs=static]",
                 "gmp": "[libs=static]",
                 "mpfr": "[libs=static]",
                 "zstd": "[libs=static]",
-                "zlib": "[~shared]"
-            }
+                "zlib": "[~shared]",
+            },
         }
         gcc["specs"] = raw["gcc"]["specs"]
         gcc["requires"] = bootstrap_spec
@@ -239,7 +261,8 @@ class Recipe:
 
                 if spec.startswith("llvm"):
                     llvm["specs"].append(
-                        f"{spec} +clang targets=x86 ~gold ^ninja@kitware")
+                        f"{spec} +clang targets=x86 ~gold ^ninja@kitware"
+                    )
 
             llvm["requires"] = raw["llvm"]["requires"]
             compilers["llvm"] = llvm
@@ -249,52 +272,54 @@ class Recipe:
     # The path of the default configuration for the target system/cluster
     @property
     def configs_path(self):
-        system = self.config['system']
-        return self.root / 'share' / 'cluster-config' / system
+        system = self.config["system"]
+        return self.root / "share" / "cluster-config" / system
 
-    # Boolean flag that indicates whether the recipe is configured to use 
+    # Boolean flag that indicates whether the recipe is configured to use
     # a binary cache.
     def generate_compilers(self):
         files = {}
 
-        template_path = self.root / 'templates'
+        template_path = self.root / "templates"
         env = jinja2.Environment(
-            loader = jinja2.FileSystemLoader(template_path),
-            trim_blocks=True, lstrip_blocks=True)
+            loader=jinja2.FileSystemLoader(template_path),
+            trim_blocks=True,
+            lstrip_blocks=True,
+        )
 
-        makefile_template = env.get_template('Makefile.compilers')
+        makefile_template = env.get_template("Makefile.compilers")
         push_to_cache = self.mirror.source and self.mirror.key
-        files['makefile'] = makefile_template.render(
-            compilers=self.compilers,
-            push_to_cache=push_to_cache)
+        files["makefile"] = makefile_template.render(
+            compilers=self.compilers, push_to_cache=push_to_cache
+        )
 
         # generate compilers/<compiler>/spack.yaml
-        files['config'] = {}
+        files["config"] = {}
         for compiler, config in self.compilers.items():
-            spack_yaml_template = env.get_template(
-                f'compilers.{compiler}.spack.yaml')
-            files['config'][compiler] = spack_yaml_template.render(
-                config=config)
+            spack_yaml_template = env.get_template(f"compilers.{compiler}.spack.yaml")
+            files["config"][compiler] = spack_yaml_template.render(config=config)
 
         return files
 
     def generate_environments(self):
         files = {}
 
-        template_path = self.root / 'templates'
+        template_path = self.root / "templates"
         jenv = jinja2.Environment(
-            loader = jinja2.FileSystemLoader(template_path),
-            trim_blocks=True, lstrip_blocks=True)
+            loader=jinja2.FileSystemLoader(template_path),
+            trim_blocks=True,
+            lstrip_blocks=True,
+        )
 
-        makefile_template = jenv.get_template('Makefile.environments')
+        makefile_template = jenv.get_template("Makefile.environments")
         push_to_cache = self.mirror.source and self.mirror.key
-        files['makefile'] = makefile_template.render(
-            environments=self.environments,
-            push_to_cache=push_to_cache)
+        files["makefile"] = makefile_template.render(
+            environments=self.environments, push_to_cache=push_to_cache
+        )
 
-        files['config'] = {}
+        files["config"] = {}
         for env, config in self.environments.items():
-            spack_yaml_template = jenv.get_template('environments.spack.yaml')
-            files['config'][env] = spack_yaml_template.render(config=config)
+            spack_yaml_template = jenv.get_template("environments.spack.yaml")
+            files["config"][env] = spack_yaml_template.render(config=config)
 
         return files

--- a/stackinator/repo/packages/cray-mpich/package.py
+++ b/stackinator/repo/packages/cray-mpich/package.py
@@ -11,6 +11,7 @@ from spack.package import *
 
 class CrayMpich(Package):
     """Install cray-mpich as a binary package"""
+
     """Intended to override the main cray-mpich"""
 
     homepage = "https://www.hpe.com/us/en/compute/hpc/hpc-software.html"
@@ -18,26 +19,36 @@ class CrayMpich(Package):
 
     maintainers = ["haampie"]
 
-
-    version("8.1.23-gcc",
-            sha256="2d1dfda811848d278548b0d7735f17341c70380dbf7f91dc680e5afcfb5e0038",
-            url="https://jfrog.svc.cscs.ch/artifactory/cray-mpich/cray-mpich-8.1.23-gcc.tar.gz")
-    version("8.1.23-nvhpc",
-            sha256="1dd9b161c538dbac564ecff6f1552220ba40dcc9436dc855087438f29861eba1",
-            url="https://jfrog.svc.cscs.ch/artifactory/cray-mpich/cray-mpich-8.1.23-nvhpc.tar.gz")
-    version("8.1.21.1-gcc",
-            sha256="0a6852ebf06afd249285fd09566e8489300cba96ad66e90c40df36b6af9a631e",
-            url="https://jfrog.svc.cscs.ch/artifactory/cray-mpich/cray-mpich-8.1.21.1-gcc.tar.gz")
-    version("8.1.21.1-nvhpc",
-            sha256="791b39f2ecb933060abaa8c8704e71da01c6962c4211cc99d12b9d964e9be4cb",
-            url="https://jfrog.svc.cscs.ch/artifactory/cray-mpich/cray-mpich-8.1.21.1-nvhpc.tar.gz")
-    version("8.1.18.4-gcc",
-            sha256="776c695aeed62b3f64a1bca11b30a2537a907777a8664d2f092e3deac288e4ad",
-            url="https://jfrog.svc.cscs.ch/artifactory/cray-mpich/cray-mpich-8.1.18.4-gcc.tar.gz")
-    version("8.1.18.4-nvhpc",
-            sha256="2285433363c75a04ccdf4798be5b0e296e0c9a8fb8fcb38eb0aa4ccf8d1e0843",
-            url="https://jfrog.svc.cscs.ch/artifactory/cray-mpich/cray-mpich-8.1.18.4-nvhpc.tar.gz")
-
+    version(
+        "8.1.23-gcc",
+        sha256="2d1dfda811848d278548b0d7735f17341c70380dbf7f91dc680e5afcfb5e0038",
+        url="https://jfrog.svc.cscs.ch/artifactory/cray-mpich/cray-mpich-8.1.23-gcc.tar.gz",
+    )
+    version(
+        "8.1.23-nvhpc",
+        sha256="1dd9b161c538dbac564ecff6f1552220ba40dcc9436dc855087438f29861eba1",
+        url="https://jfrog.svc.cscs.ch/artifactory/cray-mpich/cray-mpich-8.1.23-nvhpc.tar.gz",
+    )
+    version(
+        "8.1.21.1-gcc",
+        sha256="0a6852ebf06afd249285fd09566e8489300cba96ad66e90c40df36b6af9a631e",
+        url="https://jfrog.svc.cscs.ch/artifactory/cray-mpich/cray-mpich-8.1.21.1-gcc.tar.gz",
+    )
+    version(
+        "8.1.21.1-nvhpc",
+        sha256="791b39f2ecb933060abaa8c8704e71da01c6962c4211cc99d12b9d964e9be4cb",
+        url="https://jfrog.svc.cscs.ch/artifactory/cray-mpich/cray-mpich-8.1.21.1-nvhpc.tar.gz",
+    )
+    version(
+        "8.1.18.4-gcc",
+        sha256="776c695aeed62b3f64a1bca11b30a2537a907777a8664d2f092e3deac288e4ad",
+        url="https://jfrog.svc.cscs.ch/artifactory/cray-mpich/cray-mpich-8.1.18.4-gcc.tar.gz",
+    )
+    version(
+        "8.1.18.4-nvhpc",
+        sha256="2285433363c75a04ccdf4798be5b0e296e0c9a8fb8fcb38eb0aa4ccf8d1e0843",
+        url="https://jfrog.svc.cscs.ch/artifactory/cray-mpich/cray-mpich-8.1.18.4-nvhpc.tar.gz",
+    )
 
     variant("cuda", default=False)
     variant("rocm", default=False)
@@ -181,4 +192,6 @@ class CrayMpich(Package):
 
         filter_file("@@GTL_LIBRARY@@", gtl_library, self.prefix.bin.mpicc, string=True)
         filter_file("@@GTL_LIBRARY@@", gtl_library, self.prefix.bin.mpicxx, string=True)
-        filter_file("@@GTL_LIBRARY@@", gtl_library, self.prefix.bin.mpifort, string=True)
+        filter_file(
+            "@@GTL_LIBRARY@@", gtl_library, self.prefix.bin.mpifort, string=True
+        )

--- a/stackinator/schema.py
+++ b/stackinator/schema.py
@@ -1,12 +1,14 @@
 import json
-import jsonschema
 import pathlib
+
+import jsonschema
 import yaml
 
 prefix = pathlib.Path(__file__).parent.resolve()
 
 # create a validator that will insert optional fields with their default values
 # if they have not been provided.
+
 
 def extend_with_default(validator_class):
     validate_properties = validator_class.VALIDATORS["properties"]
@@ -17,20 +19,25 @@ def extend_with_default(validator_class):
                 instance.setdefault(property, subschema["default"])
 
         for error in validate_properties(
-            validator, properties, instance, schema,
+            validator,
+            properties,
+            instance,
+            schema,
         ):
             yield error
 
     return jsonschema.validators.extend(
-        validator_class, {"properties" : set_defaults},
+        validator_class,
+        {"properties": set_defaults},
     )
+
 
 validator = extend_with_default(jsonschema.Draft7Validator)
 
 # load recipe yaml schema
-config_schema = json.load(open(prefix / 'schema/config.json'))
+config_schema = json.load(open(prefix / "schema/config.json"))
 config_validator = validator(config_schema)
-compilers_schema = json.load(open(prefix / 'schema/compilers.json'))
+compilers_schema = json.load(open(prefix / "schema/compilers.json"))
 compilers_validator = validator(compilers_schema)
-environments_schema = json.load(open(prefix / 'schema/environments.json'))
+environments_schema = json.load(open(prefix / "schema/environments.json"))
 environments_validator = validator(environments_schema)

--- a/test_stackinator.py
+++ b/test_stackinator.py
@@ -3,13 +3,12 @@
 import pathlib
 import sys
 
-
 prefix = pathlib.Path(__file__).parent.resolve()
-external = prefix / 'external'
+external = prefix / "external"
 sys.path = [prefix.as_posix(), external.as_posix()] + sys.path
 
 import pytest
 
-if __name__ == '__main__':
-    sys.argv = [sys.argv[0], '-vv', 'unittests']
+if __name__ == "__main__":
+    sys.argv = [sys.argv[0], "-vv", "unittests"]
     sys.exit(pytest.main())

--- a/unittests/test_schema.py
+++ b/unittests/test_schema.py
@@ -1,119 +1,130 @@
 #!/usr/bin/python3
 
 import pathlib
+
 import pytest
 import yaml
 
 import stackinator.schema as schema
 
+
 @pytest.fixture
 def test_path():
     return pathlib.Path(__file__).parent.resolve()
 
+
 @pytest.fixture
 def yaml_path(test_path):
-    return test_path / 'yaml'
+    return test_path / "yaml"
+
 
 @pytest.fixture
 def recipes():
-    return ['host-recipe', 'base-amdgpu', 'base-nvgpu', 'cache', 'unique-bootstrap']
+    return ["host-recipe", "base-amdgpu", "base-nvgpu", "cache", "unique-bootstrap"]
+
 
 @pytest.fixture
 def recipe_paths(test_path, recipes):
-    return [test_path / 'recipes' / r for r in recipes]
+    return [test_path / "recipes" / r for r in recipes]
+
 
 def test_config_yaml(yaml_path):
     # test that the defaults are set as expected
-    with open(yaml_path / 'config.defaults.yaml') as fid:
+    with open(yaml_path / "config.defaults.yaml") as fid:
         raw = yaml.load(fid, Loader=yaml.Loader)
         schema.validator(schema.config_schema).validate(raw)
-        assert raw['store'] == '/user-environment'
-        assert raw['spack']['commit'] == None
-        assert raw['modules'] == True
-        assert raw['mirror'] == {'enable': True, 'key': None}
+        assert raw["store"] == "/user-environment"
+        assert raw["spack"]["commit"] == None
+        assert raw["modules"] == True
+        assert raw["mirror"] == {"enable": True, "key": None}
 
-    with open(yaml_path / 'config.full.yaml') as fid:
+    with open(yaml_path / "config.full.yaml") as fid:
         raw = yaml.load(fid, Loader=yaml.Loader)
         schema.validator(schema.config_schema).validate(raw)
-        assert raw['store'] == '/alternative-point'
-        assert raw['spack']['commit'] == '6408b51'
-        assert raw['modules'] == False
-        assert raw['mirror'] == {'enable': True, 'key': '/home/bob/veryprivate.key'}
+        assert raw["store"] == "/alternative-point"
+        assert raw["spack"]["commit"] == "6408b51"
+        assert raw["modules"] == False
+        assert raw["mirror"] == {"enable": True, "key": "/home/bob/veryprivate.key"}
+
 
 def test_recipe_config_yaml(yaml_path, recipe_paths):
     # validate the config.yaml in the test recipes
     for p in recipe_paths:
-        with open(p / 'config.yaml') as fid:
+        with open(p / "config.yaml") as fid:
             raw = yaml.load(fid, Loader=yaml.Loader)
             schema.validator(schema.config_schema).validate(raw)
 
+
 def test_compilers_yaml(yaml_path, recipe_paths):
     # test that the defaults are set as expected
-    with open(yaml_path / 'compilers.defaults.yaml') as fid:
+    with open(yaml_path / "compilers.defaults.yaml") as fid:
         raw = yaml.load(fid, Loader=yaml.Loader)
         schema.validator(schema.compilers_schema).validate(raw)
-        assert raw['bootstrap'] == {'spec': 'gcc@11'}
-        assert raw['gcc'] == {'specs': ['gcc@10.2']}
-        assert raw['llvm'] == None
+        assert raw["bootstrap"] == {"spec": "gcc@11"}
+        assert raw["gcc"] == {"specs": ["gcc@10.2"]}
+        assert raw["llvm"] == None
 
-    with open(yaml_path / 'compilers.full.yaml') as fid:
+    with open(yaml_path / "compilers.full.yaml") as fid:
         raw = yaml.load(fid, Loader=yaml.Loader)
         schema.validator(schema.compilers_schema).validate(raw)
-        assert raw['bootstrap']['spec'] == 'gcc@11'
-        assert raw['gcc'] == {'specs': ['gcc@11', 'gcc@10.2', 'gcc@9.3.0']}
-        assert raw['llvm'] == {
-            'specs': ['llvm@13', 'llvm@11.2', 'nvhpc@22.11'],
-            'requires': 'gcc@10.2'
+        assert raw["bootstrap"]["spec"] == "gcc@11"
+        assert raw["gcc"] == {"specs": ["gcc@11", "gcc@10.2", "gcc@9.3.0"]}
+        assert raw["llvm"] == {
+            "specs": ["llvm@13", "llvm@11.2", "nvhpc@22.11"],
+            "requires": "gcc@10.2",
         }
+
 
 def test_recipe_compilers_yaml(yaml_path, recipe_paths):
     # validate the compilers.yaml in the test recipes
     for p in recipe_paths:
-        with open(p / 'compilers.yaml') as fid:
+        with open(p / "compilers.yaml") as fid:
             raw = yaml.load(fid, Loader=yaml.Loader)
             schema.validator(schema.compilers_schema).validate(raw)
 
+
 def test_environments_yaml(yaml_path):
-    with open(yaml_path / 'environments.full.yaml') as fid:
+    with open(yaml_path / "environments.full.yaml") as fid:
         raw = yaml.load(fid, Loader=yaml.Loader)
         schema.validator(schema.environments_schema).validate(raw)
 
         # the defaults-env does not set fields
         # test that they have been set to the defaults correctly
 
-        assert 'defaults-env' in raw
-        env = raw['defaults-env']
+        assert "defaults-env" in raw
+        env = raw["defaults-env"]
 
         # test the required fields were read correctly
-        assert env['compiler'] == [{'toolchain': 'gcc', 'spec': 'gcc@11'}]
-        assert env['specs'] == ['tree']
+        assert env["compiler"] == [{"toolchain": "gcc", "spec": "gcc@11"}]
+        assert env["specs"] == ["tree"]
 
         # test defaults were set correctly
-        assert env['unify'] == True
-        assert env['packages'] == []
-        assert env['variants'] == []
-        assert env['mpi'] == None
+        assert env["unify"] == True
+        assert env["packages"] == []
+        assert env["variants"] == []
+        assert env["mpi"] == None
 
         # the full-env sets all of the fields
         # test that they have been read correctly
 
-        assert 'full-env' in raw
-        env = raw['full-env']
-        assert env['compiler'] == [
-                {'toolchain': 'gcc', 'spec': 'gcc@11'},
-                {'toolchain': 'gcc', 'spec': 'gcc@12'}
+        assert "full-env" in raw
+        env = raw["full-env"]
+        assert env["compiler"] == [
+            {"toolchain": "gcc", "spec": "gcc@11"},
+            {"toolchain": "gcc", "spec": "gcc@12"},
         ]
-        assert env['specs'] == ['osu-micro-benchmarks@5.9','hdf5 +mpi']
+        assert env["specs"] == ["osu-micro-benchmarks@5.9", "hdf5 +mpi"]
 
         # test defaults were set correctly
-        assert env['unify'] == 'when_possible'
-        assert env['packages'] == ['perl', 'git']
-        assert env['mpi'] == {'spec': 'cray-mpich', 'gpu': 'cuda'}
-        assert env['variants'] == ['+mpi', '+cuda']
+        assert env["unify"] == "when_possible"
+        assert env["packages"] == ["perl", "git"]
+        assert env["mpi"] == {"spec": "cray-mpich", "gpu": "cuda"}
+        assert env["variants"] == ["+mpi", "+cuda"]
+
 
 def test_recipe_environments_yaml(yaml_path, recipe_paths):
     # validate the environments.yaml in the test recipes
     for p in recipe_paths:
-        with open(p / 'environments.yaml') as fid:
+        with open(p / "environments.yaml") as fid:
             raw = yaml.load(fid, Loader=yaml.Loader)
             schema.validator(schema.environments_schema).validate(raw)


### PR DESCRIPTION
This PR
* Formats the codebase with `black`
* Formats the codebase with `isort`
* Adds `isort.cfg`
* Adds `lint.yaml` action to enforce `black` and `isort`

A separate PR will follow with `flake8` and `mypy`; I didn't want to add those changes here so that they can be properly reviewed. This PR consists only in the result of `black .` and `sort .`.

In the separate PR, I'll also add a `.git-blame-ignore-revs` with the appropriate commit hash so that the changes in this PR will be ignored by `git blame`.