### PR TITLE
Allow user-provided packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,10 @@ spack:
       compiler: [gcc@11.3]
 ```
 
+### repo
+
+New or custom versions of a Spack package can be added to the `alps` repo. If a `repo/` folder is provided, `stackinator` will copy all the Spack packages in `repo/packages/` into the `alps` repo (the same repo providing `cray-mpich`). If the user provides a `repo.yaml` file in the `repo/` folder, the file will be ignored (and a warning is emitted).
+
 ### modules
 
 Modules are generated for the installed compilers and packages by spack. The default module generation rules set by the version of spack specified in `config.yaml` will be used if no `modules.yaml` file is provided.

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ spack:
 
 ### repo
 
-New or custom versions of a Spack package can be added to the `alps` repo. If a `repo/` folder is provided, `stackinator` will copy all the Spack packages in `repo/packages/` into the `alps` repo (the same repo providing `cray-mpich`). If the user provides a `repo.yaml` file in the `repo/` folder, the file will be ignored (and a warning is emitted).
+New Spack packages or custom versions of a package can be added to the `alps` repo. If a `repo/` folder is provided, `stackinator` will copy all the Spack packages in `repo/packages/` into the `alps` repo (the same repo providing `cray-mpich`). If the user provides a `repo.yaml` file in the `repo/` folder, the file will be ignored (and a warning is emitted).
 
 ### modules
 

--- a/stackinator/builder.py
+++ b/stackinator/builder.py
@@ -194,11 +194,12 @@ class Builder:
         # Add user-defined repo to internal repo
         user_repo_path = recipe.path / "repo"
         if user_repo_path.exists() and user_repo_path.is_dir():
-            # If user provides repo.yaml, use this instead
-            # Overwrites repos_yaml_template
             user_repo_yaml = user_repo_path / "repo.yaml"
             if user_repo_yaml.exists():
-                shutil.copy(user_repo_yaml, repo_dst / "repo.yaml")
+                self._logger.warning(f"Found 'repo.yaml' file in {user_repo_path}")
+                self._logger.warning(
+                    "'repo.yaml' is ignored, packages are added to the 'alps' repo"
+                )
 
             # Copy user-provided recipes into repo
             user_repo_packages = user_repo_path / "packages"

--- a/stackinator/builder.py
+++ b/stackinator/builder.py
@@ -191,6 +191,23 @@ class Builder:
             )
             f.write("\n")
 
+        # Add user-defined repo to internal repo
+        user_repo_path = recipe.path / "repo"
+        if user_repo_path.exists() and user_repo_path.is_dir():
+            # If user provides repo.yaml, use this instead
+            # Overwrites repos_yaml_template
+            user_repo_yaml = user_repo_path / "repo.yaml"
+            if user_repo_yaml.exists():
+                shutil.copy(user_repo_yaml, repo_dst / "repo.yaml")
+
+            # Copy user-provided recipes into repo
+            user_repo_packages = user_repo_path / "packages"
+            for user_recipe_dir in user_repo_packages.iterdir():
+                if user_recipe_dir.is_dir():  # FIXME: iterdir() yelds files too
+                    shutil.copytree(
+                        user_recipe_dir, repo_dst / "packages" / user_recipe_dir.name
+                    )
+
         # Generate the makefile and spack.yaml files that describe the compilers
         compilers = recipe.generate_compilers()
         compiler_path = self.path / "compilers"

--- a/unittests/recipes/with-repo/compilers.yaml
+++ b/unittests/recipes/with-repo/compilers.yaml
@@ -1,0 +1,5 @@
+bootstrap:
+  spec: gcc@11
+gcc:
+  specs:
+  - gcc@11

--- a/unittests/recipes/with-repo/config.yaml
+++ b/unittests/recipes/with-repo/config.yaml
@@ -1,0 +1,6 @@
+name: with-repo
+store: '/user-environment'
+system: 'hohgant'
+spack:
+    repo: https://github.com/spack/spack.git
+    commit: v18.1

--- a/unittests/recipes/with-repo/environments.yaml
+++ b/unittests/recipes/with-repo/environments.yaml
@@ -1,0 +1,18 @@
+gcc-env:
+  compiler:
+      - toolchain: gcc
+        spec: gcc@11.3.0
+  unify: true
+  specs:
+  - osu-micro-benchmarks@5.9
+  - hdf5 +mpi
+  mpi:
+    spec: cray-mpich
+    gpu: false
+tools:
+  compiler:
+      - toolchain: gcc
+        spec: gcc@11.3.0
+  unify: true
+  specs:
+  - cmake

--- a/unittests/recipes/with-repo/repo/packages/dummy/package.py
+++ b/unittests/recipes/with-repo/repo/packages/dummy/package.py
@@ -1,4 +1,5 @@
-from spack imporr *
+from spack import *
+
 
 class Dummy(Package):
     pass

--- a/unittests/recipes/with-repo/repo/packages/dummy/package.py
+++ b/unittests/recipes/with-repo/repo/packages/dummy/package.py
@@ -1,0 +1,4 @@
+from spack imporr *
+
+class Dummy(Package):
+    pass

--- a/unittests/test_schema.py
+++ b/unittests/test_schema.py
@@ -20,7 +20,7 @@ def yaml_path(test_path):
 
 @pytest.fixture
 def recipes():
-    return ["host-recipe", "base-amdgpu", "base-nvgpu", "cache", "unique-bootstrap"]
+    return ["host-recipe", "base-amdgpu", "base-nvgpu", "cache", "unique-bootstrap", "with-repo"]
 
 
 @pytest.fixture

--- a/unittests/test_schema.py
+++ b/unittests/test_schema.py
@@ -20,7 +20,14 @@ def yaml_path(test_path):
 
 @pytest.fixture
 def recipes():
-    return ["host-recipe", "base-amdgpu", "base-nvgpu", "cache", "unique-bootstrap", "with-repo"]
+    return [
+        "host-recipe",
+        "base-amdgpu",
+        "base-nvgpu",
+        "cache",
+        "unique-bootstrap",
+        "with-repo",
+    ]
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR adds support for user-provided packages, so that custom packages can be provided when building the stack. These packages can be new ones, or versions taking precedence over the ones in upstream Spack (as for the `cray-mpich` package).

You can find example recipes here: https://github.com/RMeli/spack-stack-alps/tree/main/hohgant/tests

The recipe structure is the following:

```bash
.
├── compilers.yaml
├── config.yaml
├── environments.yaml
├── mirrors.yaml
└── repo
    ├── packages
    │   └── elpa
    │       └── package.py
    └── repo.yaml
```

Besides the usual suspects, the user can now provide a `repo` directory defining a [Spack repository](https://spack.readthedocs.io/en/latest/repositories.html). The `repo.yaml` file is optional and will overwrite the `stackinator/repo/repo.yaml` one.

---

@toxa81, this addition might be useful to build Spack stack with packages that are currently broken upstream (such as `libxc`).