### PR TITLE
Fix bwrap mounting for broken links

### DIFF
--- a/stackinator/etc/bwrap-mutable-root.sh
+++ b/stackinator/etc/bwrap-mutable-root.sh
@@ -3,7 +3,7 @@ args=()
 shopt -s dotglob
 for d in /*; do
     # skip invalid symlinks, as they will break bwrap
-    if [ ! -L "$d" ] || [ -e "$" ]; then
+    if [ ! -L "$d" ] || [ -e "$d" ]; then
         args+=("--dev-bind" "$d" "$d")
     fi
 done

--- a/stackinator/etc/bwrap-mutable-root.sh
+++ b/stackinator/etc/bwrap-mutable-root.sh
@@ -2,7 +2,7 @@
 args=()
 shopt -s dotglob
 for d in /*; do
-    # skip invalide symlinks, as they will break bwrap
+    # skip invalid symlinks, as they will break bwrap
     if [ ! -L "$d" ] || [ -e "$" ]; then
         args+=("--dev-bind" "$d" "$d")
     fi

--- a/stackinator/etc/bwrap-mutable-root.sh
+++ b/stackinator/etc/bwrap-mutable-root.sh
@@ -2,6 +2,9 @@
 args=()
 shopt -s dotglob
 for d in /*; do
-  args+=("--dev-bind" "$d" "$d")
+    # skip invalide symlinks, as they will break bwrap
+    if [ ! -L "$d" ] || [ -e "$" ]; then
+        args+=("--dev-bind" "$d" "$d")
+    fi
 done
 bwrap "${args[@]}" "$@"


### PR DESCRIPTION
If there is a broken symlink in root, the bwrap wrapper will fail.
Fix this by mounting everything _except_ invalid symlinks.