### PR TITLE
Fix builds with v0.20 of spack

### DIFF
--- a/stackinator/templates/Makefile.compilers
+++ b/stackinator/templates/Makefile.compilers
@@ -18,7 +18,7 @@ all:{% for compiler in compilers %} {{ compiler }}/generated/build_cache{% endfo
 {% for compiler, config in compilers.items() %}
 {{ compiler }}/generated/build_cache: {{ compiler }}/generated/env
 {% if push_to_cache %}
-	$(SPACK) -e ./{{ compiler }} buildcache create --rebuild-index --allow-root --only=package -m alpscache $$($(SPACK) -e ./{{ compiler }} find --format '/$${hash}')
+	$(SPACK) -e ./{{ compiler }} buildcache create --rebuild-index --allow-root --only=package -m alpscache $$($(SPACK) --color=never -e ./{{ compiler }} find --format '/{hash}')
 {% endif %}
 	touch $@
 
@@ -43,11 +43,11 @@ all:{% for compiler in compilers %} {{ compiler }}/generated/build_cache{% endfo
 {% endfor %}
 # Configure dependencies between compilers
 gcc/compilers.yaml: bootstrap/generated/env
-	$(SPACK) compiler find --scope=user $(call compiler_bin_dirs, $$($(SPACK) -e ./bootstrap find --format '{prefix}' {{ compilers.gcc.requires }}))
+	$(SPACK) compiler find --scope=user $(call compiler_bin_dirs, $$($(SPACK) --color=never -e ./bootstrap find --format '{prefix}' {{ compilers.gcc.requires }}))
 
 {% if compilers.llvm %}
 llvm/compilers.yaml: gcc/generated/env
-	$(SPACK) compiler find --scope=user $(call compiler_bin_dirs, $$($(SPACK) -e ./gcc find --format '{prefix}' {{ compilers.llvm.requires }}))
+	$(SPACK) compiler find --scope=user $(call compiler_bin_dirs, $$($(SPACK) --color=never -e ./gcc find --format '{prefix}' {{ compilers.llvm.requires }}))
 {% endif %}
 
 

--- a/stackinator/templates/Makefile.environments
+++ b/stackinator/templates/Makefile.environments
@@ -17,7 +17,7 @@ all:{% for env in environments %} {{ env }}/generated/build_cache{% endfor %}
 {% for env, config in environments.items() %}
 {{ env }}/generated/build_cache: {{ env }}/generated/env
 {% if push_to_cache %}
-	$(SPACK) -e ./{{ env }} buildcache create --rebuild-index --allow-root --only=package -m alpscache $$($(SPACK) -e ./{{ env }} find --format '/$${hash}')
+	$(SPACK) -e ./{{ env }} buildcache create --rebuild-index --allow-root --only=package -m alpscache $$($(SPACK) --color=never -e ./{{ env }} find --format '/{hash}')
 {% endif %}
 	touch $@
 
@@ -27,7 +27,7 @@ all:{% for env in environments %} {{ env }}/generated/build_cache{% endfor %}
 
 # Create the compilers.yaml configuration for each environment
 {% for env, config in environments.items() %}
-{{ env }}_PREFIX = {% for C in config.compiler %} $$($(SPACK) -e ../compilers/{{ C.toolchain }} find --format '{prefix}' {{ C.spec }}){% endfor %}
+{{ env }}_PREFIX = {% for C in config.compiler %} $$($(SPACK) --color=never -e ../compilers/{{ C.toolchain }} find --format '{prefix}' {{ C.spec }}){% endfor %}
 
 {{ env }}/compilers.yaml:
 	$(SPACK) compiler find --scope=user $(call compiler_bin_dirs, $({{ env }}_PREFIX))


### PR DESCRIPTION
Sometime around v0.20, Spack started colorizing the output of `spack -e ... find --format '/{hash}'`, which we were piping straight into another Spack command. Hilarity ensues.