### PR TITLE
Don't push large binary images to build caches

### DIFF
--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -150,7 +150,7 @@ class Recipe:
         environments = raw
 
         # enumerate large binary packages that should not be pushed to binary caches
-        for name, config in environments.items():
+        for _, config in environments.items():
             config["exclude_from_cache"] = ["cuda"]
 
         # check the environment descriptions and ammend where features are missing

--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -149,6 +149,10 @@ class Recipe:
     def generate_environment_specs(self, raw):
         environments = raw
 
+        # enumerate large binary packages that should not be pushed to binary caches
+        for name, config in environments.items():
+            config["exclude_from_cache"] = ["cuda"]
+
         # check the environment descriptions and ammend where features are missing
         for name, config in environments.items():
             if ("specs" not in config) or (config["specs"] is None):
@@ -223,6 +227,7 @@ class Recipe:
             f"{bootstrap_spec} languages=c,c++",
             "squashfs default_compression=zstd",
         ]
+        bootstrap["exclude_from_cache"] = []
         compilers["bootstrap"] = bootstrap
 
         gcc = {}
@@ -249,6 +254,7 @@ class Recipe:
         }
         gcc["specs"] = raw["gcc"]["specs"]
         gcc["requires"] = bootstrap_spec
+        gcc["exclude_from_cache"] = []
         compilers["gcc"] = gcc
         if raw["llvm"] is not None:
             llvm = {}
@@ -264,6 +270,7 @@ class Recipe:
                     )
 
             llvm["requires"] = raw["llvm"]["requires"]
+            llvm["exclude_from_cache"] = ["nvhpc"]
             compilers["llvm"] = llvm
 
         self.compilers = compilers

--- a/stackinator/templates/Makefile.compilers
+++ b/stackinator/templates/Makefile.compilers
@@ -20,7 +20,7 @@ all:{% for compiler in compilers %} {{ compiler }}/generated/build_cache{% endfo
 {{ compiler }}/generated/build_cache: {{ compiler }}/generated/env
 {% if push_to_cache %}
 	$(SPACK) -e ./{{ compiler }} buildcache create --rebuild-index --allow-root --only=package -m alpscache \
-	$$($(SPACK) --color=never -e ./{{ compiler }} find --format '{name};/{hash}' \
+	$$($(SPACK) --color=never -e ./{{ compiler }} find --format '{name};{/hash}' \
 	| grep -v -E '^({% for p in config.exclude_from_cache %}{{ pipejoiner() }}{{ p }}{% endfor %});'\
 	| cut -d ';' -f2)
 {% endif %}

--- a/stackinator/templates/Makefile.compilers
+++ b/stackinator/templates/Makefile.compilers
@@ -1,3 +1,4 @@
+{% set pipejoiner = joiner('|') %}
 -include ../Make.user
 
 MAKEFLAGS += --output-sync=recurse
@@ -18,9 +19,15 @@ all:{% for compiler in compilers %} {{ compiler }}/generated/build_cache{% endfo
 {% for compiler, config in compilers.items() %}
 {{ compiler }}/generated/build_cache: {{ compiler }}/generated/env
 {% if push_to_cache %}
-	$(SPACK) -e ./{{ compiler }} buildcache create --rebuild-index --allow-root --only=package -m alpscache $$($(SPACK) --color=never -e ./{{ compiler }} find --format '/{hash}')
+	$(SPACK) -e ./{{ compiler }} buildcache create --rebuild-index --allow-root --only=package -m alpscache \
+	$$($(SPACK) --color=never -e ./{{ compiler }} find --format '{name};/{hash}') \
+	| grep -v -E '^({% for p in config.exclude_from_cache %}{{ pipejoiner() }}{{ p }}{% endfor %});'\
+	| cut -d ';' -f2)
 {% endif %}
 	touch $@
+
+spack find --format "{name};{hash}" | grep -v -E "^()" | cut -d ';' -f2
+compiler: [{% for c in config.compiler %}{{ separator() }}{{ c.spec }}{% endfor %}]
 
 {% endfor %}
 

--- a/stackinator/templates/Makefile.compilers
+++ b/stackinator/templates/Makefile.compilers
@@ -20,13 +20,12 @@ all:{% for compiler in compilers %} {{ compiler }}/generated/build_cache{% endfo
 {{ compiler }}/generated/build_cache: {{ compiler }}/generated/env
 {% if push_to_cache %}
 	$(SPACK) -e ./{{ compiler }} buildcache create --rebuild-index --allow-root --only=package -m alpscache \
-	$$($(SPACK) --color=never -e ./{{ compiler }} find --format '{name};/{hash}') \
+	$$($(SPACK) --color=never -e ./{{ compiler }} find --format '{name};/{hash}' \
 	| grep -v -E '^({% for p in config.exclude_from_cache %}{{ pipejoiner() }}{{ p }}{% endfor %});'\
 	| cut -d ';' -f2)
 {% endif %}
 	touch $@
 
-spack find --format "{name};{hash}" | grep -v -E "^()" | cut -d ';' -f2
 compiler: [{% for c in config.compiler %}{{ separator() }}{{ c.spec }}{% endfor %}]
 
 {% endfor %}

--- a/stackinator/templates/Makefile.compilers
+++ b/stackinator/templates/Makefile.compilers
@@ -26,8 +26,6 @@ all:{% for compiler in compilers %} {{ compiler }}/generated/build_cache{% endfo
 {% endif %}
 	touch $@
 
-compiler: [{% for c in config.compiler %}{{ separator() }}{{ c.spec }}{% endfor %}]
-
 {% endfor %}
 
 # Configure the install location.

--- a/stackinator/templates/Makefile.environments
+++ b/stackinator/templates/Makefile.environments
@@ -1,3 +1,4 @@
+{% set pipejoiner = joiner('|') %}
 -include ../Make.user
 
 MAKEFLAGS += --output-sync=recurse
@@ -17,7 +18,10 @@ all:{% for env in environments %} {{ env }}/generated/build_cache{% endfor %}
 {% for env, config in environments.items() %}
 {{ env }}/generated/build_cache: {{ env }}/generated/env
 {% if push_to_cache %}
-	$(SPACK) -e ./{{ env }} buildcache create --rebuild-index --allow-root --only=package -m alpscache $$($(SPACK) --color=never -e ./{{ env }} find --format '/{hash}')
+	$(SPACK) -e ./{{ env }} buildcache create --rebuild-index --allow-root --only=package -m alpscache \
+	$$($(SPACK) --color=never -e ./{{ env }} find --format '{name};/{hash}' \
+	| grep -v -E '^({% for p in config.exclude_from_cache %}{{ pipejoiner() }}{{ p }}{% endfor %});'\
+	| cut -d ';' -f2)
 {% endif %}
 	touch $@
 

--- a/stackinator/templates/Makefile.environments
+++ b/stackinator/templates/Makefile.environments
@@ -19,7 +19,7 @@ all:{% for env in environments %} {{ env }}/generated/build_cache{% endfor %}
 {{ env }}/generated/build_cache: {{ env }}/generated/env
 {% if push_to_cache %}
 	$(SPACK) -e ./{{ env }} buildcache create --rebuild-index --allow-root --only=package -m alpscache \
-	$$($(SPACK) --color=never -e ./{{ env }} find --format '{name};/{hash}' \
+	$$($(SPACK) --color=never -e ./{{ env }} find --format '{name};{/hash}' \
 	| grep -v -E '^({% for p in config.exclude_from_cache %}{{ pipejoiner() }}{{ p }}{% endfor %});'\
 	| cut -d ';' -f2)
 {% endif %}


### PR DESCRIPTION
Some large packages take an extreme length of time to push to build caches.

For example, `nvhpc` and `cuda` which are 5-15 GB in size, can take 10 minutes.
These are binary pacakges, that do not need to be built, so subsequent time savings
might not be worth the time added by pushing to a cache the first time that they are
installed.

This PR introduces a change that selectively filters `nvhpc` and `cuda` when enumerating
the packages to push to a cache.
The feature could be later extended to give users more control over which packages to skip.

Fixes #95 