### PR TITLE
improve env.json meta data; add description to config

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -22,12 +22,14 @@ spack:
     repo: https://github.com/spack/spack.git
     commit: releases/v0.20
 modules: true
+description: "HPC development tools for building MPI applications with the GNU compiler toolchain"
 ```
 
 * `name`: a plain text name for the environment
 * `store`: the location where the environment will be mounted.
 * `spack`: which spack repository to use for installation.
 * `modules`: _optional_ enable/diasble module file generation (default `true`).
+* `description`: _optional_ a string that describes the environment.
 
 ## Compilers
 

--- a/stackinator/builder.py
+++ b/stackinator/builder.py
@@ -87,7 +87,7 @@ class Builder:
             "default": {
               "root": /user-environment/env/default,
               "activate": /user-environment/env/default/activate.sh,
-              "description": "your standard development environment: compilers, MPI, python, cmake."
+              "description": "simple devolpment env: compilers, MPI, python, cmake."
             },
             "tools": {
               "root": /user-environment/env/tools,

--- a/stackinator/schema/config.json
+++ b/stackinator/schema/config.json
@@ -49,6 +49,13 @@
         "modules" : {
             "type": "boolean",
             "default": true
+        },
+        "description" : {
+            "oneOf": [
+                {"type" : "string"},
+                {"type" : "null"}
+            ],
+            "default": null
         }
     }
 }

--- a/unittests/recipes/host-recipe/config.yaml
+++ b/unittests/recipes/host-recipe/config.yaml
@@ -1,5 +1,6 @@
 name: host-example
 store: /user-environment
+description: "An example gcc configuration for CPU-only development"
 spack:
   commit: releases/v0.20
   repo: https://github.com/spack/spack.git

--- a/unittests/test_schema.py
+++ b/unittests/test_schema.py
@@ -44,7 +44,7 @@ def test_config_yaml(yaml_path):
         assert raw["spack"]["commit"] is None
         assert raw["modules"] == True  # noqa: E712
         assert raw["mirror"] == {"enable": True, "key": None}
-        assert raw["description"] == None
+        assert raw["description"] is None
 
     with open(yaml_path / "config.full.yaml") as fid:
         raw = yaml.load(fid, Loader=yaml.Loader)

--- a/unittests/test_schema.py
+++ b/unittests/test_schema.py
@@ -44,6 +44,7 @@ def test_config_yaml(yaml_path):
         assert raw["spack"]["commit"] is None
         assert raw["modules"] == True  # noqa: E712
         assert raw["mirror"] == {"enable": True, "key": None}
+        assert raw["description"] == None
 
     with open(yaml_path / "config.full.yaml") as fid:
         raw = yaml.load(fid, Loader=yaml.Loader)
@@ -52,7 +53,7 @@ def test_config_yaml(yaml_path):
         assert raw["spack"]["commit"] == "6408b51"
         assert raw["modules"] == False  # noqa: E712
         assert raw["mirror"] == {"enable": True, "key": "/home/bob/veryprivate.key"}
-
+        assert raw["description"] == "a really useful environment"
 
 def test_recipe_config_yaml(recipe_paths):
     # validate the config.yaml in the test recipes

--- a/unittests/yaml/config.full.yaml
+++ b/unittests/yaml/config.full.yaml
@@ -7,3 +7,4 @@ mirror:
     key: /home/bob/veryprivate.key
     enable: True
 modules: False
+description: "a really useful environment"


### PR DESCRIPTION
* add `description` field to `config.yaml`
* add more information about the environment, views, modules, etc to `meta/env.json`. See below

```json
{
  "description": "An example gcc configuration for CPU-only development",
  "modules": {
    "root": "/user-environment/modules"
  },
  "name": "host-example",
  "views": {
    "default": {
      "activate": "/user-environment/env/default/activate.sh",
      "description": "",
      "root": "/user-environment/env/default"
    },
    "no-python": {
      "activate": "/user-environment/env/no-python/activate.sh",
      "description": "",
      "root": "/user-environment/env/no-python"
    },
    "roots": {
      "activate": "/user-environment/env/roots/activate.sh",
      "description": "",
      "root": "/user-environment/env/roots"
    },
    "run": {
      "activate": "/user-environment/env/run/activate.sh",
      "description": "",
      "root": "/user-environment/env/run"
    }
  }
}
```

fixes #110