### PR TITLE
add unshare workflow proto

### DIFF
--- a/stackinator/templates/Make.user
+++ b/stackinator/templates/Make.user
@@ -11,6 +11,9 @@ SPACK := spack
 # The Spack installation root.
 STORE := {{ store }}
 
+{% if unshare %}
+SANDBOX :=
+{% else %}
 # When already building inside a sandbox, use `SANDBOX :=` (empty string)
 # Without a sandbox, make sure to hide sensitive data such as ~/.ssh through bubblewrap.
 # Also bind the directories `./tmp -> /tmp` and `./store -> $(STORE)`, so that
@@ -22,16 +25,20 @@ SANDBOX := $(SOFTWARE_STACK_PROJECT)/bwrap-mutable-root.sh $\
 	--tmpfs ~ $\
 	--bind $(SOFTWARE_STACK_PROJECT)/tmp /tmp $\
 	--bind $(SOFTWARE_STACK_PROJECT)/store $(STORE)
+{% endif %}
 
 # Makes sure that make -Orecurse continues to print in color.
 export SPACK_COLOR := always
 
+{% if unshare %}
+export SPACK_USER_CONFIG_PATH := /fake-home
+{% else %}
 # Do not use user config, cause more often than not you pick up the wrong
 # config files in ~/.spack. Note that our recommended bwrap setup already puts
 # a tmpfs in the home folder, but when bwrap isn't used, this also helps a bit
 # with reproducibility.
 export SPACK_USER_CONFIG_PATH := /dev/null
-
+{% endif %}
 # Set up the system config scope that has the system packages we don't want
 # build, for example slurm, pmix, etc. Also should have the system compiler.
 export SPACK_SYSTEM_CONFIG_PATH := $(SOFTWARE_STACK_PROJECT)/config

--- a/stackinator/templates/unshare-newroot.sh
+++ b/stackinator/templates/unshare-newroot.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+
+# This script uses unshare(1), rather than bubblewrap, to create a sandbox with
+# a writable root.
+
+_dir=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")
+
+## Helper functions ##
+
+fatal () {
+    printf 'error: %s' $1 1>2
+    exit 1
+}
+
+print_debug () {
+    [[ -z "$UNS_DEBUG" ]] || printf '[debug] %s\n' $1
+}
+
+print_verbose () {
+    [[ -z "$UNS_VERBOSE" ]] || printf '[verbose] %s\n' $1
+}
+
+## Namespace manipulation ##
+
+newroot_make () {
+    if [[ -e "$newroot" ]] && [[ ! -d "$newroot" ]]; then
+        printf 'error: newroot: %s: exists but is not a directory' "$newroot" 1>&2
+        exit 1
+    fi
+    if [[ -d "$newroot" ]]; then
+        printf "removing existing: newroot: %s\n" "$newroot"
+        rm -rf --one-file-system "$newroot"
+    fi
+    printf "creating: newroot: %s\n" "$newroot"
+    mkdir "$newroot"
+
+    # Create mount points in newroot for files in '/'.
+    find / -maxdepth 1 -not -wholename '/' | while read f; do mk_mnt_p "$f"; done
+}
+
+newroot_init () {
+    # Ensure that the newroot exists.
+    [[ -d "$newroot" ]] || fatal 'newroot: %s: does not exist'
+
+    # At this point, we should be masquerading as root, i.e., this process
+    # should be inside a unique user and mount namespace. The intended use
+    # is as follows.
+    #
+    # $ unshare --user --map-user-root --mount ./newroot.sh \
+    #           env --ignore-environment PATH=/usr/bin:`pwd`/spack/bin make \
+    #           store.squashfs [...]
+    #
+    # FIXME: check if we are masquerading as root in a user and mount
+    #        namespace.
+
+    # Claim the newroot, /tmp/$USER.newroot, in our unshared namespace by
+    # recusrively bind-mounting it over itself.
+    mount --rbind --make-private "$newroot" "$newroot"
+
+    # We do the same with /tmp. You would think that because /tmp contains
+    # /tmp/$USER.newroot and it's a recursive bind mount, we could claim both
+    # same call. But, we know this causes pivot_root(2) to fail later with
+    # EBUSY; thus, we claim it here to avoid potential issues with tools that
+    # may be used later, e.g., chroot, unshare (nested), pivot_root(1).
+    #
+    # Note: unlike the bubblewrap workflow, our newroot exists in tmp; thus,
+    # we can set {{build_path}} to /dev/shm/$USER.build and avoid mounting
+    # {{ build_path }}/tmp to /tmp at build time.
+    mount --rbind --make-private /tmp /tmp
+
+    # Recursively bind mount host / top-level, i.e., depth 1, files to the
+    # corresponding points created by mk_mount_p. Exclude '/' itself to avoid
+    # losing write permissions to newroot.
+    find / -maxdepth 1 -not -wholename '/' | while read f; do mount_ "$f"; done
+
+    # Create the store mount point, e.g., /user-environment
+    mkdir -p "${newroot}/${store_path}"
+
+    # Create a TMPFS 'fake' home directory that Spack can write to. This file
+    # is intentionally lost to the ether, to avoid re-using any
+    # related configurations spack may write at build-time.
+    #
+    # Note, unlike manipulating Spack to write these configs to `/dev/null`,
+    # we allow spack to write to a temporary file. We found this useful when
+    # manipulating bootstrap and mirrors URLs at make/build time.
+    mkdir -p "${newroot}/${spack_user_path}"
+    mount -t tmpfs none "${newroot}/${spack_user_path}"
+}
+
+mk_mnt_p() {
+    # Check if the src file is a directory. We do not care if a directory
+    # is a symlink; we will follow the link via readlink and the absolute path
+    # to the destination mount point."
+    if [[ -d $1 ]]; then
+        mkdir "${newroot}$1"
+    else
+        touch "${newroot}$1"
+    fi
+}
+
+# Mount: bind, recursive, private.
+mount_ () {
+    f=$(readlink_f "$1")
+    mount --rbind --make-private "$f" "${newroot}$1"
+}
+
+
+# Return absolute path if symlink.
+readlink_f () {
+    if [[ -L $1 ]]; then
+        echo "$(readlink -f "$1")"
+    else
+        echo "$1"
+    fi
+}
+
+newroot={{newroot}}
+build_path={{build_path}}
+store_path={{store}}
+spack_user_path=/fake-home
+
+# These variables should be set via jinja2 at this point; otherwise, error.
+[[ -n "$newroot" ]]    || fatal 'var: NEWROOT: empty'
+[[ -n "$build_path" ]] || fatal 'var: SOFTWARE_STACK_PROJECT: empty'
+[[ -n "$store_path" ]] || fatal 'var: STORE: empty'
+[[ -n "$spack_user_path" ]] || fatal 'var: SPACK_USER_CONFIG_PATH: empty'
+
+if [[ -n "$UNS_DEBUG" ]]; then
+    set -xe
+fi
+
+# Create the newroot and list the mount points.
+newroot_make
+find "$newroot"
+
+# Claim newroot and bind files to newroot.
+newroot_init
+
+# "Pivot" the root and exec to command, e.g., `env [...] make store.squashfs`.
+exec unshare --root="$newroot" --wd="$build_path" $@


### PR DESCRIPTION
This PR adds an `unshare(1)` workflow prototype. It creates a writable root "sandbox" at `/tmp/$USER.newroot` and uses `unshare(1)` to manipulate user and mount namespaces. It is my hope that you folks will adopt and support this.

This is useful for those whom cannot use `bubblewrap` or setuid helpers. FWIW, you can create and mount squashfs files with a setuid-stripped `fusermount3` binary using nested namespaces (see: https://github.com/hpc/charliecloud/pull/1415).

There are improvements to be had. For example, I have not tried concurrent builds of different environments. I suspect that won't work, out of the box, with what I've provided here.

```
$ ./bin/stack-config -s /foo/bar/unshare/system-config/cagnusmarlson -r /foo/bar/unshare/recipe -b /dev/shm/$USER.build --unshare
Stackinator
  recipe path:  /foo/bar/unshare/recipe
  build path :  /dev/shm/jogas.build
  system     :  /foo/bar/unshare/system-config/cagnusmarlson
  mount      :  default
  build cache:  None
  sandbox tool: unshare
spack: checkout branch/commit internal-0.20.0

Configuration finished, run the following to build the environment:

cd /dev/shm/jogas.build
unshare -U -m -r ./newroot.sh env --ignore-environment PATH=/usr/bin:/bin:`pwd`/spack/bin make store.squashfs -j32
```
```
$ cd /dev/shm/jogas.build
$ unshare -U -m -r ./newroot.sh env --ignore-environment PATH=/usr/bin:/bin:`pwd`/spack/bin make store.squashfs -j32
creating: newroot: /tmp/jogas.newroot
/tmp/jogas.newroot
[...]
/tmp/jogas.newroot/apps
/tmp/jogas.newroot/data
[...]
/tmp/jogas.newroot/var
/tmp/jogas.newroot/usr
/tmp/jogas.newroot/tmp
/tmp/jogas.newroot/sys
/tmp/jogas.newroot/srv
/tmp/jogas.newroot/selinux
/tmp/jogas.newroot/sbin
/tmp/jogas.newroot/run
/tmp/jogas.newroot/root
/tmp/jogas.newroot/proc
[...]
/tmp/jogas.newroot/net
/tmp/jogas.newroot/mnt
/tmp/jogas.newroot/lib64
/tmp/jogas.newroot/lib
[...]
/tmp/jogas.newroot/home
/tmp/jogas.newroot/etc
/tmp/jogas.newroot/dev
[...]
/tmp/jogas.newroot/boot
/tmp/jogas.newroot/bin
/tmp/jogas.newroot/.profile
/tmp/jogas.newroot/.wificonfig
spack arch... linux-firehose
spack version... 0.21.0.dev0 (2c07392e3087a19735c73f6ee6e9a185e8fd0464)
checking if spack concretizer works... ==> Warning: Failed to initialize repository: '/fun-stack/repo'.
  No repo.yaml found in '/fun-stack/repo'
  To remove the bad repository, run this command:
      spack repo rm /fun-stack/repo
yup
touch mirror-setup
make -C compilers
make[1]: Entering directory '/dev/shm/jogas.build/compilers'
[...]
mkdir -p /fun-stack
touch bootstrap/compilers.yaml
spack -e gcc/ concretize -f
[...]
 -   tivowgn  gcc@11.3.0%gcc@11.4.0~binutils+bootstrap~graphite~nvptx~piclibs~profiled+strip build_system=autotools build_type=Release languages=c,c++,fortran patches=cc6112d arch=linux-firehose
 -   apih3cj      ^diffutils@3.9%gcc@11.4.0 build_system=autotools arch=linux-firehose
 -   pze3z5p          ^libiconv@1.17%gcc@11.4.0 build_system=autotools libs=shared,static arch=linux-firehose
``` 