### PR TITLE
fix build cache error message

### DIFF
--- a/stackinator/cache.py
+++ b/stackinator/cache.py
@@ -40,7 +40,7 @@ def configuration_from_file(file, mount):
                 )
             if not key.is_file():
                 raise FileNotFoundError(
-                        f"The build cache key '{path}' does not exist"
+                        f"The build cache key '{key}' does not exist"
                 )
             raw["key"] = key
 


### PR DESCRIPTION
When using a `cache-config.yaml` with an invalid entry for `key`, stackinator printed the following message:

```
The build cache key '/scratch/e1000/simonpi/uenv-cache' does not exist        
```
Seems to be a copy/paste error reusing the previous block for `path`