### PR TITLE
set $HOME to ~

### DIFF
--- a/stackinator/main.py
+++ b/stackinator/main.py
@@ -83,7 +83,7 @@ def main():
         )
         root_logger.info(f"cd {builder.path}")
         root_logger.info(
-            "env --ignore-environment PATH=/usr/bin:/bin:`pwd`"
+            "env --ignore-environment PATH=/usr/bin:/bin:`pwd` HOME=~"
             "/spack/bin make store.squashfs -j32"
         )
         return 0


### PR DESCRIPTION
When trying to install matplotlib, `font-util` installation failed:
```
/usr/bin/fc-cache /user-environment/linux-sles15-zen2/gcc-11.4.0/font-util-1.4.0-b6tqwcjmvtuzuybtahwl7oa5gpxqvctm/share/fonts/X11/100dpi
/user-environment/linux-sles15-zen2/gcc-11.4.0/font-util-1.4.0-b6tqwcjmvtuzuybtahwl7oa5gpxqvctm/share/fonts/X11/100dpi: failed to write cache
make[4]: *** [Makefile:890: install-data-hook] Error 1
make[4]: Leaving directory '/tmp/simonpi/spack-stage/spack-stage-font-util-1.4.0-b6tqwcjmvtuzuybtahwl7oa5gpxqvctm/spack-src/font-adobe-100dpi/font-adobe-100dpi-1.0.3'
make[3]: *** [Makefile:778: install-data-am] Error 2
make[3]: Leaving directory '/tmp/simonpi/spack-stage/spack-stage-font-util-1.4.0-b6tqwcjmvtuzuybtahwl7oa5gpxqvctm/spack-src/font-adobe-100dpi/font-adobe-100dpi-1.0.3'
```

In `./stack-debug.sh`:
```
fc-cache -v
# failed to write cache
HOME=~ fc-cache -v
# works
```

@bcumming This error came up in February already. Curiously you proposed to set $HOME in slack back then.
Not sure I'm missing something, but setting `env --ignore-environment HOME=~` fixed it now.


