### PR TITLE
fix --with-view argument in develop

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -42,5 +42,6 @@ In order to use Spack's `develop` branch it is possible to configure the Spack s
 The `--develop` option does the following:
  
 * Use build cache mirror name as positional argument instead of using the removed `-m` option ([stackinator#115](https://github.com/eth-cscs/stackinator/issues/115))
+* `spack env --with-view <name>` requires an argument.
 
 Once the supported Spack releases are updated, the changes introduced by `--develop` will be used by default.

--- a/stackinator/templates/Makefile.environments
+++ b/stackinator/templates/Makefile.environments
@@ -38,8 +38,13 @@ all:{% for env in environments %} {{ env }}/generated/build_cache{% endfor %}
 {% for env, config in environments.items() %}
 {{ env }}/generated/view_config: {{ env }}/generated/env
 {% if config.view %}
+{% if develop %}
+	$(SPACK) env activate --with-view {{ config.view.name }} --sh ./{{ env }} > $(STORE)/env/{{ config.view.name }}/activate.sh
+	$(SOFTWARE_STACK_PROJECT)/add-compiler-links.py  ./{{ env }}/compilers.yaml $(STORE)/env/{{ config.view.name }}/activate.sh $(SOFTWARE_STACK_PROJECT)
+{% else %}
 	$(SPACK) env activate --with-view --sh ./{{ env }} > $(STORE)/env/{{ config.view.name }}/activate.sh
 	$(SOFTWARE_STACK_PROJECT)/add-compiler-links.py  ./{{ env }}/compilers.yaml $(STORE)/env/{{ config.view.name }}/activate.sh $(SOFTWARE_STACK_PROJECT)
+{% endif %}
 {% endif %}
 	touch $@
 


### PR DESCRIPTION
`spack env activate` has changed `--with-view` flag, it requires an argument in latest develop:
```
usage: spack env activate [-hp] [--sh | --csh | --fish | --bat | --pwsh] [--with-view name | --without-view] [--temp] [-d DIR]
                          [env]

positional arguments:
  env                   name of environment to activate

options:
...
  --with-view name, -v name
                        set runtime environment variables for specific view
...
````
