### PR TITLE
use `install` instead of `cp` in makefile

### DIFF
--- a/stackinator/templates/Makefile.generate-config
+++ b/stackinator/templates/Makefile.generate-config
@@ -22,10 +22,10 @@ $(CONFIG_DIR)/upstreams.yaml:
 # Copy the cluster-specific packages.yaml file to the configuration.
 # requires compilers.yaml to ensure that the path $(CONFIG_DIR) has been created.
 $(CONFIG_DIR)/packages.yaml: $(CONFIG_DIR)/compilers.yaml
-	cp $(SOFTWARE_STACK_PROJECT)/config/packages.yaml $(CONFIG_DIR)/packages.yaml
+	install -m 644 $(SOFTWARE_STACK_PROJECT)/config/packages.yaml $(CONFIG_DIR)/packages.yaml
 
 $(CONFIG_DIR)/repos.yaml: $(CONFIG_DIR)/compilers.yaml
-	cp $(SOFTWARE_STACK_PROJECT)/config/repos.yaml $(CONFIG_DIR)/repos.yaml
+	install -m 644 $(SOFTWARE_STACK_PROJECT)/config/repos.yaml $(CONFIG_DIR)/repos.yaml
 
 # Generate a configuration used to generate the module files
 # The configuration in CONFIG_DIR can't be used for this purpose, because a compilers.yaml


### PR DESCRIPTION
Besides `builder.py` there were also files copied using `cp` to `/store`. Replace it by `install -m 644` to make sure the created image is world readable.