### PR TITLE
Make `environment:mpi:gpu` optional

### DIFF
--- a/stackinator/schema.py
+++ b/stackinator/schema.py
@@ -14,7 +14,7 @@ def extend_with_default(validator_class):
     validate_properties = validator_class.VALIDATORS["properties"]
 
     def set_defaults(validator, properties, instance, schema):
-        # if instance is none, it is not possible to set any default for any sub-property
+        # if instance is none, it's not possible to set any default for any sub-property
         if instance is not None:
             for property, subschema in properties.items():
                 if "default" in subschema:

--- a/stackinator/schema.py
+++ b/stackinator/schema.py
@@ -14,9 +14,11 @@ def extend_with_default(validator_class):
     validate_properties = validator_class.VALIDATORS["properties"]
 
     def set_defaults(validator, properties, instance, schema):
-        for property, subschema in properties.items():
-            if "default" in subschema:
-                instance.setdefault(property, subschema["default"])
+        # if instance is none, it is not possible to set any default for any sub-property
+        if instance is not None:
+            for property, subschema in properties.items():
+                if "default" in subschema:
+                    instance.setdefault(property, subschema["default"])
 
         for error in validate_properties(
             validator,

--- a/stackinator/schema/environments.json
+++ b/stackinator/schema/environments.json
@@ -40,7 +40,10 @@
                              "additionalProperties": false,
                              "properties": {
                                  "spec": {"type": "string"},
-                                 "gpu":  {"enum": ["cuda", "rocm", null, false]}
+                                 "gpu":  {
+					 "enum": ["cuda", "rocm", null, false],
+					 "default": null
+				 }
                              }
                          },
                          {"enum": [null, false]}

--- a/unittests/test_schema.py
+++ b/unittests/test_schema.py
@@ -115,6 +115,10 @@ def test_environments_yaml(yaml_path):
         assert env["mpi"] is None
         assert env["views"] == {}
 
+        env = raw["defaults-env-mpi-nogpu"]
+        assert env["mpi"]["spec"] is not None
+        assert env["mpi"]["gpu"] is None
+
         # the full-env sets all of the fields
         # test that they have been read correctly
 

--- a/unittests/yaml/environments.full.yaml
+++ b/unittests/yaml/environments.full.yaml
@@ -30,3 +30,11 @@ defaults-env:
   # assert mpi=None
   # assert packages=[]
   # assert view=True
+defaults-env-mpi-nogpu:
+  compiler:
+  - toolchain: gcc
+    spec: gcc@11
+  specs:
+  - tree
+  mpi:
+    spec: cray-mpich


### PR DESCRIPTION
This PR:
- extends tests with a basic test-case with an environment where `mpi:gpu` field is not specified
- fix schema to have a default for the `mpi:gpu` field (default = `null`)
- fix validator to deal with non-existing sections

About this latter point, since I don't have any experience with this library, I'd like to ask you to double check (see comment in the code) if it is the correct reason/solution.

### Reference

According to the documentation the `mpi:gpu` field is optional, but the schema and validator were not supporting that.

https://github.com/eth-cscs/stackinator/blob/e8219f5168eccd455ab0b6c46ad6c48f9657dec8/docs/recipes.md?plain=1#L141-L147

https://github.com/eth-cscs/stackinator/blob/e8219f5168eccd455ab0b6c46ad6c48f9657dec8/docs/recipes.md?plain=1#L149-L161