### PR TITLE
Support Spack v0.21; Deprecate v0.19

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -24,7 +24,10 @@ The following flags are optional:
 
 ## Using Spack's `develop` branch
  
-We support the latest two minor versions of Spack. Since Spack has no stable major release yet, it has a short gap between deprecation and removal.
+Stackinator supports the latest two minor versions of Spack. Since Spack has no stable major release yet, it has a short gap between deprecation and removal.
+
+!!! note
+    Currently v0.20 and v0.21 of Spack are supported, with best effort support of the latest developments in the `develop` branch of Spack (see below).
 
 In order to use Spack's `develop` branch it is possible to configure the Spack stacks using the `--develop`.
 
@@ -39,9 +42,12 @@ In order to use Spack's `develop` branch it is possible to configure the Spack s
 
 ### Current Support
 
-The `--develop` option does the following:
+The `--develop` option currently handles the following the following:
  
-* Use build cache mirror name as positional argument instead of using the removed `-m` option ([stackinator#115](https://github.com/eth-cscs/stackinator/issues/115))
 * `spack env --with-view <name>` requires an argument.
+    * v0.20 and earlier did not accept a named argument to `spack env --with-view`, instead requiring the presence of a view named `default`.
+    * v0.21 requires the name of the view be passed as a positional argument.
+    * if `--develop` is passed, or `v0.21` is detected.
+    * will be removed when v0.21 is the oldest supported version of Spack.
 
 Once the supported Spack releases are updated, the changes introduced by `--develop` will be used by default.

--- a/stackinator/builder.py
+++ b/stackinator/builder.py
@@ -172,6 +172,7 @@ class Builder:
         tmp_path.mkdir(exist_ok=True)
 
         # check out the version of spack
+        spack_version = recipe.spack_version
         spack = recipe.config["spack"]
         spack_path = self.path / "spack"
 
@@ -234,6 +235,7 @@ class Builder:
                     post_install_hook=recipe.post_install_hook,
                     pre_install_hook=recipe.pre_install_hook,
                     develop=self.spack_develop,
+                    spack_version=spack_version,
                     verbose=False,
                 )
             )

--- a/stackinator/main.py
+++ b/stackinator/main.py
@@ -41,6 +41,7 @@ def log_header(args):
     mount = args.mount or "default"
     root_logger.info(f"  mount      : {mount}")
     root_logger.info(f"  build cache: {args.cache}")
+    root_logger.info(f"  develop    : {args.develop}")
 
 
 def make_argparser():

--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -302,13 +302,13 @@ class Recipe:
         # An awkward hack to work around spack not supporting creating activation
         # scripts for each file system view in an environment: it only generates them
         # for the "default" view.
-        # The workaround is to create multiple versions of the same environment, one for
-        # each view.
-        # TODO: remove when the minimum supported version of spack is v0.21, in which this
-        # issue was fixed, see https://github.com/spack/spack/pull/40549
-        # we have a `--develop` workaround that uses the current approach of generating a
-        # separate environment for each view, with a view named "default", and uses the name
-        # default to generated the activation script.
+        # The workaround is to create multiple versions of the same environment, one
+        # for each view.
+        # TODO: remove when the minimum supported version of spack is v0.21, in which
+        # this issue was fixed, see https://github.com/spack/spack/pull/40549
+        # we have a `--develop` workaround that uses the current approach of generating
+        # a separate environment for each view, with a view named "default", and uses
+        # the name default to generated the activation script.
         env_names = set()
         env_name_map = {}
         for name, config in environments.items():

--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -210,16 +210,16 @@ class Recipe:
         # determine the "major" version, if it can be inferred.
         # one of "0.20", "0.21", "develop" or "unknown".
         commit = self.config["spack"]["commit"]
-        if commit is None or commit=="develop":
+        if commit is None or commit == "develop":
             return "develop"
         # currently supported
-        if commit.find("0.20")>=0:
+        if commit.find("0.20") >= 0:
             return "0.20"
         # currently supported
-        if commit.find("0.21")>=0:
+        if commit.find("0.21") >= 0:
             return "0.21"
         # branches that contain wip for the next v0.22 release
-        if commit.find("0.22")>=0:
+        if commit.find("0.22") >= 0:
             return "0.22"
 
         return "unknown"
@@ -494,7 +494,7 @@ class Recipe:
             environments=self.environments,
             push_to_cache=push_to_cache,
             develop=self.spack_develop,
-            spack_version=self.spack_version
+            spack_version=self.spack_version,
         )
 
         files["config"] = {}

--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -221,7 +221,6 @@ class Recipe:
         # branches that contain wip for the next v0.22 release
         if commit.find("0.22")>=0:
             return "0.22"
-        spack_version=spack_version,
 
         return "unknown"
 

--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -206,6 +206,26 @@ class Recipe:
             self._config = raw
 
     @property
+    def spack_version(self):
+        # determine the "major" version, if it can be inferred.
+        # one of "0.20", "0.21", "develop" or "unknown".
+        commit = self.config["spack"]["commit"]
+        if commit is None or commit=="develop":
+            return "develop"
+        # currently supported
+        if commit.find("0.20")>=0:
+            return "0.20"
+        # currently supported
+        if commit.find("0.21")>=0:
+            return "0.21"
+        # branches that contain wip for the next v0.22 release
+        if commit.find("0.22")>=0:
+            return "0.22"
+        spack_version=spack_version,
+
+        return "unknown"
+
+    @property
     def environment_view_meta(self):
         # generate the view meta data that is presented in the squashfs image meta data
         view_meta = {}
@@ -475,6 +495,7 @@ class Recipe:
             environments=self.environments,
             push_to_cache=push_to_cache,
             develop=self.spack_develop,
+            spack_version=self.spack_version
         )
 
         files["config"] = {}

--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -285,8 +285,11 @@ class Recipe:
         # for the "default" view.
         # The workaround is to create multiple versions of the same environment, one for
         # each view.
-        # TODO: remove when the minimum supported version of Spack supports generation
-        # for more than one view.
+        # TODO: remove when the minimum supported version of spack is v0.21, in which this
+        # issue was fixed, see https://github.com/spack/spack/pull/40549
+        # we have a `--develop` workaround that uses the current approach of generating a
+        # separate environment for each view, with a view named "default", and uses the name
+        # default to generated the activation script.
         env_names = set()
         env_name_map = {}
         for name, config in environments.items():

--- a/stackinator/templates/Makefile
+++ b/stackinator/templates/Makefile
@@ -75,13 +75,8 @@ cache-force: mirror-setup
 	$(warning likely have to start a fresh build (but that's okay, because build caches FTW))
 	$(warning ================================================================================)
 	$(SANDBOX) $(MAKE) -C generate-config
-{% if develop %}
 	$(SANDBOX) $(SPACK) -C $(STORE)/config buildcache create --rebuild-index --allow-root --only=package alpscache \
 	$$($(SANDBOX) $(SPACK) --color=never -C $(STORE)/config find --format '{/hash}')
-{% else %}
-	$(SANDBOX) $(SPACK) -C $(STORE)/config buildcache create --rebuild-index --allow-root --only=package -m alpscache \
-	$$($(SANDBOX) $(SPACK) --color=never -C $(STORE)/config find --format '{/hash}')
-{% endif %}
 {% else %}
 	$(warning "pushing to the build cache is not enabled. See the documentation on how to add a key: https://eth-cscs.github.io/stackinator/build-caches/")
 {% endif %}

--- a/stackinator/templates/Makefile.compilers
+++ b/stackinator/templates/Makefile.compilers
@@ -19,17 +19,10 @@ all:{% for compiler in compilers %} {{ compiler }}/generated/build_cache{% endfo
 {% for compiler, config in compilers.items() %}
 {{ compiler }}/generated/build_cache: {{ compiler }}/generated/env
 {% if push_to_cache %}
-{% if develop %}
 	$(SPACK) -e ./{{ compiler }} buildcache create --rebuild-index --allow-root --only=package alpscache \
 	$$($(SPACK) --color=never -e ./{{ compiler }} find --format '{name};{/hash}' \
 	| grep -v -E '^({% for p in config.exclude_from_cache %}{{ pipejoiner() }}{{ p }}{% endfor %});'\
 	| cut -d ';' -f2)
-{% else %}
-	$(SPACK) -e ./{{ compiler }} buildcache create --rebuild-index --allow-root --only=package -m alpscache \
-	$$($(SPACK) --color=never -e ./{{ compiler }} find --format '{name};{/hash}' \
-	| grep -v -E '^({% for p in config.exclude_from_cache %}{{ pipejoiner() }}{{ p }}{% endfor %});'\
-	| cut -d ';' -f2)
-{% endif %}
 {% endif %}
 	touch $@
 

--- a/stackinator/templates/Makefile.environments
+++ b/stackinator/templates/Makefile.environments
@@ -39,7 +39,7 @@ all:{% for env in environments %} {{ env }}/generated/build_cache{% endfor %}
 {{ env }}/generated/view_config: {{ env }}/generated/env
 {% if config.view %}
 {% if develop %}
-	$(SPACK) env activate --with-view {{ config.view.name }} --sh ./{{ env }} > $(STORE)/env/{{ config.view.name }}/activate.sh
+	$(SPACK) env activate --with-view default --sh ./{{ env }} > $(STORE)/env/{{ config.view.name }}/activate.sh
 	$(SOFTWARE_STACK_PROJECT)/add-compiler-links.py  ./{{ env }}/compilers.yaml $(STORE)/env/{{ config.view.name }}/activate.sh $(SOFTWARE_STACK_PROJECT)
 {% else %}
 	$(SPACK) env activate --with-view --sh ./{{ env }} > $(STORE)/env/{{ config.view.name }}/activate.sh

--- a/stackinator/templates/Makefile.environments
+++ b/stackinator/templates/Makefile.environments
@@ -18,17 +18,10 @@ all:{% for env in environments %} {{ env }}/generated/build_cache{% endfor %}
 {% for env, config in environments.items() %}
 {{ env }}/generated/build_cache: {{ env }}/generated/view_config
 {% if push_to_cache %}
-{% if develop %}
 	$(SPACK) -e ./{{ env }} buildcache create --rebuild-index --allow-root --only=package alpscache \
 	$$($(SPACK) --color=never -e ./{{ env }} find --format '{name};{/hash}' \
 	| grep -v -E '^({% for p in config.exclude_from_cache %}{{ pipejoiner() }}{{ p }}{% endfor %});'\
 	| cut -d ';' -f2)
-{% else %}
-	$(SPACK) -e ./{{ env }} buildcache create --rebuild-index --allow-root --only=package -m alpscache \
-	$$($(SPACK) --color=never -e ./{{ env }} find --format '{name};{/hash}' \
-	| grep -v -E '^({% for p in config.exclude_from_cache %}{{ pipejoiner() }}{{ p }}{% endfor %});'\
-	| cut -d ';' -f2)
-{% endif %}
 {% endif %}
 	touch $@
 
@@ -38,7 +31,7 @@ all:{% for env in environments %} {{ env }}/generated/build_cache{% endfor %}
 {% for env, config in environments.items() %}
 {{ env }}/generated/view_config: {{ env }}/generated/env
 {% if config.view %}
-{% if develop %}
+{% if develop or (spack_version=="0.21") %}
 	$(SPACK) env activate --with-view default --sh ./{{ env }} > $(STORE)/env/{{ config.view.name }}/activate.sh
 	$(SOFTWARE_STACK_PROJECT)/add-compiler-links.py  ./{{ env }}/compilers.yaml $(STORE)/env/{{ config.view.name }}/activate.sh $(SOFTWARE_STACK_PROJECT)
 {% else %}


### PR DESCRIPTION
* fix `spack env --with-view default` bug
* add official support for v0.21
    * `--develop` is no longer required
* add `spack_version` information that can be accessed during configuration, in case two supported versions require different configurations.
* update the documentation to reflect the changes.