### PR TITLE
Make spack `config:deprecated` configuration accessible in environment

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -80,13 +80,14 @@ To provide a single Spack stack that meets the workflow's needs, we would create
 ```yaml title="environments.yaml high level overview"
 # A GCC-based programming environment
 prgenv-gnu:
-  compiler: # ... compiler toolchain
-  mpi:      # ... mpi configuration
-  unify:    # ... configure Spack concretizer
-  specs:    # ... list of packages to install
-  variants: # ... variants to apply to packages (e.g. +mpi)
-  packages: # ... list of external packages to use
-  views:    # ... environment views to provide to users
+  compiler:   # ... compiler toolchain
+  mpi:        # ... mpi configuration
+  deprecated: # ... whether to allow usage of deprecated packages or not
+  unify:      # ... configure Spack concretizer
+  specs:      # ... list of packages to install
+  variants:   # ... variants to apply to packages (e.g. +mpi)
+  packages:   # ... list of external packages to use
+  views:      # ... environment views to provide to users
 # An NVIDIA programming environment
 prgenv-nvgpu:
   # ... same structure as prgenv-gnu
@@ -180,6 +181,8 @@ The following versions of cray-mpich are currently provided:
 ### Specs
 
 The list of software packages to install is configured in the `spec:` field of an environment. The specs follow the [standard Spack practice](https://spack.readthedocs.io/en/latest/environments.html#spec-concretization).
+
+The `deprecated: ` field controls if Spack should consider versions marked as deprecated, and can be set to `true` or `false` (for considering or not considering deprecated versions, respectively).
 
 The `unify:` field controls the Spack concretiser, and can be set to three values `true`, `false` or `when_possible`.
 The 

--- a/stackinator/schema/environments.json
+++ b/stackinator/schema/environments.json
@@ -9,6 +9,10 @@
              "required": ["compiler", "specs"],
              "additionalProperties": false,
              "properties": {
+                 "deprecated": {
+                     "type": "boolean",
+                     "default": false
+                 },
                  "unify": {
                      "enum": ["when_possible", true, false],
                      "default": true

--- a/stackinator/templates/environments.spack.yaml
+++ b/stackinator/templates/environments.spack.yaml
@@ -6,6 +6,8 @@ spack:
 {% endif %}
   - compilers.yaml
   - config.yaml
+  config:
+    deprecated: false
   concretizer:
     unify: {{ config.unify }}
     reuse: false

--- a/stackinator/templates/environments.spack.yaml
+++ b/stackinator/templates/environments.spack.yaml
@@ -7,7 +7,7 @@ spack:
   - compilers.yaml
   - config.yaml
   config:
-    deprecated: false
+    deprecated: {{ config.deprecated }}
   concretizer:
     unify: {{ config.unify }}
     reuse: false


### PR DESCRIPTION
Sometimes there's no other way than dealing with deprecated packages. Spack by default does not allow anymore to fetch packages version marked as deprecated, but it still keeps the door open for such edge cases allowing to control the behavior via `config:deprecated`.

This PR exposes this option in `environments.yaml` keeping the default spack behavior (i.e. `false` = don't allow to install deprecated versions).

I didn't had the chance to fully test it, yet. In case this work is in the right direction, I will take care of updating the related documentation too before merging this PR.