### PR TITLE
add missing set_permissions

### DIFF
--- a/stackinator/builder.py
+++ b/stackinator/builder.py
@@ -33,6 +33,7 @@ def install(src, dst, *, ignore=None, symlinks=False):
             os.chmod(path, new_mode)
 
         for dirpath, dirnames, filenames in os.walk(directory):
+            set_permissions(dirpath)
             for dirname in dirnames:
                 set_permissions(os.path.join(dirpath, dirname))
             for filename in filenames:

--- a/stackinator/builder.py
+++ b/stackinator/builder.py
@@ -32,8 +32,8 @@ def install(src, dst, *, ignore=None, symlinks=False):
                 new_mode |= stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
             os.chmod(path, new_mode)
 
+        set_permissions(directory)
         for dirpath, dirnames, filenames in os.walk(directory):
-            set_permissions(dirpath)
             for dirname in dirnames:
                 set_permissions(os.path.join(dirpath, dirname))
             for filename in filenames:


### PR DESCRIPTION
`set_permissions` was not called for the toplevel directory in `os.walk(directory)` 