### PR TITLE
mpich 8.1.27 fixes

### DIFF
--- a/stackinator/repo/packages/cray-gtl/package.py
+++ b/stackinator/repo/packages/cray-gtl/package.py
@@ -22,7 +22,7 @@ class CrayGtl(Package):
     )
     version(
         "8.1.27",
-        sha256="c00836641c7d1f40300f8e4b068a1ba1ff4b0ca31af24b9507d768fc6fe5753c",
+        sha256="80c7e94d30b5a3573ac6b2cc5fb0373046760a0acdff44a178e723ab3c8fdfb9",
     )
     version(
         "8.1.26",

--- a/stackinator/repo/packages/cray-gtl/package.py
+++ b/stackinator/repo/packages/cray-gtl/package.py
@@ -59,8 +59,8 @@ class CrayGtl(Package):
     conflicts("+cuda", when="+rocm", msg="Pick either CUDA or ROCM")
 
     with when("+cuda"):
-        depends_on("cuda@11.0:11", type="link", when="@:8.1.27")
-        depends_on("cuda@12:", type="link", when="@8.1.28:")
+        depends_on("cuda@11.0:11", type="link", when="@:8.1.26")
+        depends_on("cuda@12.0:12", type="link", when="@8.1.27:")
 
     with when("+rocm"):
         # libamdhip64.so.5
@@ -109,3 +109,6 @@ class CrayGtl(Package):
                 # __gxx_personality_v0 but wasn't linked against libstdc++.
                 if "libmpi_gtl_cuda.so" in str(f):
                     patchelf("--add-needed", "libstdc++.so", f, fail_on_error=False)
+                if "@8.1.27" in self.spec:
+                    patchelf("--add-needed", "libcudart.so", f, fail_on_error=False)
+                    patchelf("--add-needed", "libcuda.so", f, fail_on_error=False)

--- a/stackinator/repo/packages/cray-mpich/package.py
+++ b/stackinator/repo/packages/cray-mpich/package.py
@@ -24,7 +24,7 @@ class CrayMpich(Package):
     )
     version(
         "8.1.27",
-        sha256="c555f180cbe7272acd76e3e55cd9150c2b20b8ec263228f64fe2b682eec1c612",
+        sha256="c7f2f5366aba9ff9781084a430b5b9462427ee8120069ff530d1965065ef220b",
     )
     version(
         "8.1.26",

--- a/stackinator/repo/packages/cray-pmi/package.py
+++ b/stackinator/repo/packages/cray-pmi/package.py
@@ -24,7 +24,7 @@ class CrayPmi(Package):
     )
     version(
         "6.1.12",
-        sha256="0f1caa93c881e1a5a4b5a65d1cb3a04d9c549ffdb9524b53a6e7ca9317dd90ee",
+        sha256="d1a4bd929b73197823dd9b4bcb3c8ef06d80326297a07291b24e5996b60330a8",
     )
     version(
         "6.1.11",


### PR DESCRIPTION
For unknown reasons `libmpi_gtl_cuda.so` in cray-gtl@8.1.27 was not linked again `libcuda` and `libcudart`, resulting in linker errors:
- use patchelf to link `libmpi_gtl_cuda.so` to `libcudart`/`libcuda`
- `cray-mpich@8.1.27` depends on `cuda@12`
- update sha256 for mpich 8.1.27 (regenerated tarballs using HPE repo)
- tested `osu_bw -d cuda D D` and `osu_bw H H` on `tasnam`