### PR TITLE
cray-mpich: add aarch64 versions / set rpaths

### DIFF
--- a/stackinator/repo/packages/cray-gtl/package.py
+++ b/stackinator/repo/packages/cray-gtl/package.py
@@ -115,6 +115,6 @@ class CrayGtl(Package):
                 # __gxx_personality_v0 but wasn't linked against libstdc++.
                 if "libmpi_gtl_cuda.so" in str(f):
                     patchelf("--add-needed", "libstdc++.so", f, fail_on_error=False)
-                if "@8.1.27" in self.spec:
+                if "@8.1.27+cuda" in self.spec:
                     patchelf("--add-needed", "libcudart.so", f, fail_on_error=False)
                     patchelf("--add-needed", "libcuda.so", f, fail_on_error=False)

--- a/stackinator/repo/packages/cray-gtl/package.py
+++ b/stackinator/repo/packages/cray-gtl/package.py
@@ -4,9 +4,38 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import platform
 
 import spack.compilers
 from spack.package import *
+
+_versions = {
+    "8.1.28": {
+        "Linux-aarch64": "0bb881cba502b199dadce7875bba62e7403e1c55abc6669c76a7cba7c05fa5ad",
+        "Linux-x86_64": "2e82c618648e79bdc4b8bf9394be8fd59c34ccd77f172afd11fce38beca1ecab",
+    },
+    "8.1.27": {
+        "Linux-x86_64": "80c7e94d30b5a3573ac6b2cc5fb0373046760a0acdff44a178e723ab3c8fdfb9"
+    },
+    "8.1.26": {
+        "Linux-x86_64": "37d9626cb5f851f63c9799c18a419354c6f21c77f90558472552156df9eef311"
+    },
+    "8.1.25": {
+        "Linux-x86_64": "a2e2af2037e63b64ef74d870c0bab91a8109e75eef82a30250b81b0d785ff6ae"
+    },
+    "8.1.24": {
+        "Linux-x86_64": "2fa8635f829e67844e7b30dffb092a336d257e0e769d2225030f2ccf4c1d302f"
+    },
+    "8.1.23": {
+        "Linux-x86_64": "034667c2ea49eec76ef8f79494231bad94884b99683edabf781beed01ec681e4"
+    },
+    "8.1.21": {
+        "Linux-x86_64": "78072edfcb6cc24cfefab06e824111b5b2b839551235ece68cd154bec7936a24"
+    },
+    "8.1.18": {
+        "Linux-x86_64": "5ac6b0877fd0f6afaaf391fffef41daf4d3150edc3250721c9abd4ded6b58486"
+    },
+}
 
 
 class CrayGtl(Package):
@@ -14,40 +43,17 @@ class CrayGtl(Package):
 
     homepage = "https://www.hpe.com/us/en/compute/hpc/hpc-software.html"
     url = "https://jfrog.svc.cscs.ch/artifactory/cray-mpich/cray-gtl-8.1.26.tar.gz"
-    maintainers = ["bcumming"]
+    maintainers = ["bcumming", "simonpintarelli"]
 
-    version(
-        "8.1.28",
-        sha256="2e82c618648e79bdc4b8bf9394be8fd59c34ccd77f172afd11fce38beca1ecab",
-    )
-    version(
-        "8.1.27",
-        sha256="80c7e94d30b5a3573ac6b2cc5fb0373046760a0acdff44a178e723ab3c8fdfb9",
-    )
-    version(
-        "8.1.26",
-        sha256="37d9626cb5f851f63c9799c18a419354c6f21c77f90558472552156df9eef311",
-    )
-    version(
-        "8.1.25",
-        sha256="a2e2af2037e63b64ef74d870c0bab91a8109e75eef82a30250b81b0d785ff6ae",
-    )
-    version(
-        "8.1.24",
-        sha256="2fa8635f829e67844e7b30dffb092a336d257e0e769d2225030f2ccf4c1d302f",
-    )
-    version(
-        "8.1.23",
-        sha256="034667c2ea49eec76ef8f79494231bad94884b99683edabf781beed01ec681e4",
-    )
-    version(
-        "8.1.21",
-        sha256="78072edfcb6cc24cfefab06e824111b5b2b839551235ece68cd154bec7936a24",
-    )
-    version(
-        "8.1.18",
-        sha256="5ac6b0877fd0f6afaaf391fffef41daf4d3150edc3250721c9abd4ded6b58486",
-    )
+    for ver, packages in _versions.items():
+        key = "{0}-{1}".format(platform.system(), platform.machine())
+        sha = packages.get(key)
+        if sha:
+            version(
+                ver,
+                sha256=sha,
+                url=f"https://jfrog.svc.cscs.ch/artifactory/cray-mpich/cray-gtl-{ver}.{platform.machine()}.tar.gz",
+            )
 
     variant("cuda", default=False)
     variant("rocm", default=False)

--- a/stackinator/repo/packages/cray-mpich/package.py
+++ b/stackinator/repo/packages/cray-mpich/package.py
@@ -20,31 +20,31 @@ class CrayMpich(Package):
 
     version(
         "8.1.28",
-        sha256="935fca183dabfcae1a4cfc664234537f25f1e87fb2765f32636be7352514f476",
+        sha256="d2d2c36b55259826a83d76cc7d0cff2f332fc236088a0d6b8ddf27937ea290f8",
     )
     version(
         "8.1.27",
-        sha256="c7f2f5366aba9ff9781084a430b5b9462427ee8120069ff530d1965065ef220b",
+        sha256="ac3fa0500a734a551f5af1e6987a397513c8f57594a1ffb3f61e00615c1f3224",
     )
     version(
         "8.1.26",
-        sha256="3c23cfe24b8f05e0c68a059919ac7dd77c45a333cad9aea41872a51d256b12d1",
+        sha256="2e921d75836699caa21d7a06ba818583ba8de5e170d9405c35122f3fb50b6ec3",
     )
     version(
         "8.1.25",
-        sha256="46e8c2804f5d34815bcf381e1957e749e6d7b286853bd94ae2bff73a6df39263",
+        sha256="bfd3b0a2dd1a45f50f5ff9f214d0f14e77c1ecf095d14d6fdcee8e5b6cf14d0b",
     )
     version(
         "8.1.24",
-        sha256="96876331bb7098e9ef2eea2c8bb25e479838c48b294ae5790094c19644e73a7d",
+        sha256="68f38a2833655e989e6e6187930ed5eaffa2d08cb7db4d7239a229c2f618ac08",
     )
     version(
         "8.1.23",
-        sha256="c0985424ef376b29e6f1b9c2016b8cfe6430b9ce434da9700a6c14433b47cf20",
+        sha256="9c452c76c684ec8abef3c666acbb2fb5286e76dfd48117d5dbed6cbb04ed16e4",
     )
     version(
         "8.1.21",
-        sha256="8b4e0ff9cba48ef7dcd4dd8092b35bb6456420de2dcf7b4f05d7c69f8e266de3",
+        sha256="41e8b5b1a2ca0777a1dd412df1bbcf602b27568806ee28e3ff891e6b43fd78d1",
     )
     version(
         "8.1.18",
@@ -148,10 +148,10 @@ class CrayMpich(Package):
         # link with the relevant gtl lib
         if "+cuda" in self.spec:
             lpath = self.spec["cray-gtl"].prefix.lib
-            gtl_library = f"-L{lpath} -lmpi_gtl_cuda"
+            gtl_library = f"-L{lpath} -Wl,-rpath,{lpath} -lmpi_gtl_cuda"
         elif "+rocm" in self.spec:
             lpath = self.spec["cray-gtl"].prefix.lib
-            gtl_library = f"-L{lpath} -lmpi_gtl_hsa"
+            gtl_library = f"-L{lpath} -Wl,-rpath,{lpath}  -lmpi_gtl_hsa"
         else:
             gtl_library = ""
         print("==== GTL_LIBRARY", gtl_library)

--- a/stackinator/repo/packages/cray-mpich/package.py
+++ b/stackinator/repo/packages/cray-mpich/package.py
@@ -10,8 +10,11 @@ import spack.compilers
 from spack.package import *
 
 _versions = {
+    "8.1.29": {
+        "Linux-aarch64": "6133ce31b20612a8152323d2d64211085a026ec62beacda4e8a2566d7b807605",
+    },
     "8.1.28": {
-        "Linux-aarch64": "001fe9f94274e059c060f9ff55ee84f8f2818440df9932a9504303110a95943f",
+        "Linux-aarch64": "dfd6c685adfbf070fe9d546d95b31e108ee7089a738447fa7326973a3e696e8d",
         "Linux-x86_64": "55a0a068bd8bff14f302c5371d7e2b4cf732d5c1ec875bb03e375644e1a6beab",
     },
     "8.1.27": {
@@ -75,6 +78,7 @@ class CrayMpich(Package):
         "8.1.26",
         "8.1.27",
         "8.1.28",
+        "8.1.29",
     ]:
         with when("+cuda"):
             depends_on(f"cray-gtl@{ver} +cuda", type="link", when="@" + ver)
@@ -87,6 +91,7 @@ class CrayMpich(Package):
 
     conflicts("%gcc@:7")
     conflicts("%gcc@:11", when="@8.1.28:")
+    conflicts("%nvhpc", when="@8.1.29")
 
     def setup_run_environment(self, env):
         env.set("MPICC", join_path(self.prefix.bin, "mpicc"))

--- a/stackinator/repo/packages/cray-mpich/package.py
+++ b/stackinator/repo/packages/cray-mpich/package.py
@@ -4,9 +4,38 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import platform
 
 import spack.compilers
 from spack.package import *
+
+_versions = {
+    "8.1.28": {
+        "Linux-aarch64": "dfd6c685adfbf070fe9d546d95b31e108ee7089a738447fa7326973a3e696e8d",
+        "Linux-x86_64": "55a0a068bd8bff14f302c5371d7e2b4cf732d5c1ec875bb03e375644e1a6beab",
+    },
+    "8.1.27": {
+        "Linux-x86_64": "5d59cc69b7ae2ef692ae49843bb2c7a44b5a8478d72eaf2ab1f1f6c5983eee0b"
+    },
+    "8.1.26": {
+        "Linux-x86_64": "d308cf3e254ce5873af6caee5ec683a397fed5ce92975f57e5c9215a98d8edad"
+    },
+    "8.1.25": {
+        "Linux-x86_64": "024ab0c4526670a37df7e2995172ba264454fd69c05d8ffe140c9e519397a65c"
+    },
+    "8.1.24": {
+        "Linux-x86_64": "2c3fa339511ed822892e112d3e4d5a39a634d00a31cf22e02ce843f0efcc5ae8"
+    },
+    "8.1.23": {
+        "Linux-x86_64": "ed7ff286ede30ea96dede4c53aa2ef98e8090c988a0bea764cd505ba5fcc0520"
+    },
+    "8.1.21": {
+        "Linux-x86_64": "5fda115f356c26e5d9f8cc68fe578e954a70edd10ebf007182d945345886b61a"
+    },
+    "8.1.18": {
+        "Linux-x86_64": "45d519be217cea89c58893d25826b15d99183247d15ecee9c3f64913660d79c2"
+    },
+}
 
 
 class CrayMpich(Package):
@@ -17,39 +46,15 @@ class CrayMpich(Package):
     homepage = "https://www.hpe.com/us/en/compute/hpc/hpc-software.html"
     url = "https://jfrog.svc.cscs.ch/artifactory/cray-mpich/cray-mpich-8.1.26.tar.gz"
     maintainers = ["bcumming"]
-
-    version(
-        "8.1.28",
-        sha256="d2d2c36b55259826a83d76cc7d0cff2f332fc236088a0d6b8ddf27937ea290f8",
-    )
-    version(
-        "8.1.27",
-        sha256="ac3fa0500a734a551f5af1e6987a397513c8f57594a1ffb3f61e00615c1f3224",
-    )
-    version(
-        "8.1.26",
-        sha256="2e921d75836699caa21d7a06ba818583ba8de5e170d9405c35122f3fb50b6ec3",
-    )
-    version(
-        "8.1.25",
-        sha256="bfd3b0a2dd1a45f50f5ff9f214d0f14e77c1ecf095d14d6fdcee8e5b6cf14d0b",
-    )
-    version(
-        "8.1.24",
-        sha256="68f38a2833655e989e6e6187930ed5eaffa2d08cb7db4d7239a229c2f618ac08",
-    )
-    version(
-        "8.1.23",
-        sha256="9c452c76c684ec8abef3c666acbb2fb5286e76dfd48117d5dbed6cbb04ed16e4",
-    )
-    version(
-        "8.1.21",
-        sha256="41e8b5b1a2ca0777a1dd412df1bbcf602b27568806ee28e3ff891e6b43fd78d1",
-    )
-    version(
-        "8.1.18",
-        sha256="45d519be217cea89c58893d25826b15d99183247d15ecee9c3f64913660d79c2",
-    )
+    for ver, packages in _versions.items():
+        key = "{0}-{1}".format(platform.system(), platform.machine())
+        sha = packages.get(key)
+        if sha:
+            version(
+                ver,
+                sha256=sha,
+                url=f"https://jfrog.svc.cscs.ch/artifactory/cray-mpich/cray-mpich-{ver}.{platform.machine()}.tar.gz",
+            )
 
     variant("cuda", default=False)
     variant("rocm", default=False)

--- a/stackinator/repo/packages/cray-mpich/package.py
+++ b/stackinator/repo/packages/cray-mpich/package.py
@@ -11,7 +11,7 @@ from spack.package import *
 
 _versions = {
     "8.1.28": {
-        "Linux-aarch64": "dfd6c685adfbf070fe9d546d95b31e108ee7089a738447fa7326973a3e696e8d",
+        "Linux-aarch64": "001fe9f94274e059c060f9ff55ee84f8f2818440df9932a9504303110a95943f",
         "Linux-x86_64": "55a0a068bd8bff14f302c5371d7e2b4cf732d5c1ec875bb03e375644e1a6beab",
     },
     "8.1.27": {

--- a/stackinator/repo/packages/cray-pals/package.py
+++ b/stackinator/repo/packages/cray-pals/package.py
@@ -4,9 +4,32 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import platform
 
 import spack.compilers
 from spack.package import *
+
+_versions = {
+    "1.3.2": {
+        "Linux-aarch64": "f7b97a10cc8dde17e804f79235ab1aa98f83e0c7c178e58d6ca3e9170f89c6da",
+        "Linux-x86_64": "deea749476de0f545b31fcd0912f133d7ba60b84f673e47d8b4b15d5a117254c",
+    },
+    "1.2.12": {
+        "Linux-x86_64": "c94d29c09ed650c4e98a236df7ced77f027bdf987919a91a1a1382f704a85bb9"
+    },
+    "1.2.11": {
+        "Linux-x86_64": "e1af09e39d70e28381de806548c6cb29c23abf891a078f46eb71c301a3f0994c"
+    },
+    "1.2.9": {
+        "Linux-x86_64": "ceec6f99bea9df3f7f657a7df499445e62976064dda3f3e437d61e895ec31601"
+    },
+    "1.2.5": {
+        "Linux-x86_64": "d7269ed8f4deab816e3d4006090ec68b25ccc585200d16728ed9a914baf4d9bf"
+    },
+    "1.2.4": {
+        "Linux-x86_64": "a253939585bad2bb9061b98be6e517f18bda0602ecfd38f75c734a01d12003f2"
+    },
+}
 
 
 class CrayPals(Package):
@@ -18,30 +41,15 @@ class CrayPals(Package):
     url = "https://jfrog.svc.cscs.ch/artifactory/cray-mpich/cray-pals-1.2.12.tar.gz"
     maintainers = ["simonpintarelli"]
 
-    version(
-        "1.3.2",
-        sha256="deea749476de0f545b31fcd0912f133d7ba60b84f673e47d8b4b15d5a117254c",
-    )
-    version(
-        "1.2.12",
-        sha256="c94d29c09ed650c4e98a236df7ced77f027bdf987919a91a1a1382f704a85bb9",
-    )
-    version(
-        "1.2.11",
-        sha256="e1af09e39d70e28381de806548c6cb29c23abf891a078f46eb71c301a3f0994c",
-    )
-    version(
-        "1.2.9",
-        sha256="ceec6f99bea9df3f7f657a7df499445e62976064dda3f3e437d61e895ec31601",
-    )
-    version(
-        "1.2.5",
-        sha256="d7269ed8f4deab816e3d4006090ec68b25ccc585200d16728ed9a914baf4d9bf",
-    )
-    version(
-        "1.2.4",
-        sha256="a253939585bad2bb9061b98be6e517f18bda0602ecfd38f75c734a01d12003f2",
-    )
+    for ver, packages in _versions.items():
+        key = "{0}-{1}".format(platform.system(), platform.machine())
+        sha = packages.get(key)
+        if sha:
+            version(
+                ver,
+                sha256=sha,
+                url=f"https://jfrog.svc.cscs.ch/artifactory/cray-mpich/cray-pals-{ver}.{platform.machine()}.tar.gz",
+            )
 
     # Fix up binaries with patchelf.
     depends_on("patchelf", type="build")

--- a/stackinator/repo/packages/cray-pmi/package.py
+++ b/stackinator/repo/packages/cray-pmi/package.py
@@ -4,9 +4,35 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import platform
 
 import spack.compilers
 from spack.package import *
+
+_versions = {
+    "6.1.13": {
+        "Linux-aarch64": "f865f410145a66bb05520c32ee5b64b6dfcb9ae33aace6d3db5f870e4f4714bc",
+        "Linux-x86_64": "217ac554cf84a4c7f08cd149c6a18428e1e3533d73e350fa291b6800895b632e",
+    },
+    "6.1.12": {
+        "Linux-x86_64": "d1a4bd929b73197823dd9b4bcb3c8ef06d80326297a07291b24e5996b60330a8"
+    },
+    "6.1.11": {
+        "Linux-x86_64": "5ebcece6a610da02cd41a9a386fd7463ee909bd55e3370d6d372603f90be9afe"
+    },
+    "6.1.10": {
+        "Linux-x86_64": "f4fbe75c201a171dcfe6ada773a4bf0c606767a0b7a8a76fd19d10852abe1290"
+    },
+    "6.1.9": {
+        "Linux-x86_64": "8fd4194c6c5167f8b81b1cf9b76341669e40d647d0caecef287be6f0f5d95290"
+    },
+    "6.1.8": {
+        "Linux-x86_64": "6c7e5d3038e26b9d0e82428b25b570d00401a6fc9f2fd3c008f15a253a8e2305"
+    },
+    "6.1.7": {
+        "Linux-x86_64": "574b21bd6f8970521c2bc4f096aced896fec8b749f854272cc7bbb7130ae92d8"
+    },
+}
 
 
 class CrayPmi(Package):
@@ -16,36 +42,17 @@ class CrayPmi(Package):
 
     homepage = "https://www.hpe.com/us/en/compute/hpc/hpc-software.html"
     url = "https://jfrog.svc.cscs.ch/artifactory/cray-mpich/cray-pmi-6.1.11.tar.gz"
-    maintainers = ["bcumming"]
+    maintainers = ["bcumming", "simonpintarelli"]
 
-    version(
-        "6.1.13",
-        sha256="217ac554cf84a4c7f08cd149c6a18428e1e3533d73e350fa291b6800895b632e",
-    )
-    version(
-        "6.1.12",
-        sha256="d1a4bd929b73197823dd9b4bcb3c8ef06d80326297a07291b24e5996b60330a8",
-    )
-    version(
-        "6.1.11",
-        sha256="5ebcece6a610da02cd41a9a386fd7463ee909bd55e3370d6d372603f90be9afe",
-    )
-    version(
-        "6.1.10",
-        sha256="f4fbe75c201a171dcfe6ada773a4bf0c606767a0b7a8a76fd19d10852abe1290",
-    )
-    version(
-        "6.1.9",
-        sha256="8fd4194c6c5167f8b81b1cf9b76341669e40d647d0caecef287be6f0f5d95290",
-    )
-    version(
-        "6.1.8",
-        sha256="6c7e5d3038e26b9d0e82428b25b570d00401a6fc9f2fd3c008f15a253a8e2305",
-    )
-    version(
-        "6.1.7",
-        sha256="574b21bd6f8970521c2bc4f096aced896fec8b749f854272cc7bbb7130ae92d8",
-    )
+    for ver, packages in _versions.items():
+        key = "{0}-{1}".format(platform.system(), platform.machine())
+        sha = packages.get(key)
+        if sha:
+            version(
+                ver,
+                sha256=sha,
+                url=f"https://jfrog.svc.cscs.ch/artifactory/cray-mpich/cray-pmi-{ver}.{platform.machine()}.tar.gz",
+            )
 
     # Fix up binaries with patchelf.
     depends_on("patchelf", type="build")


### PR DESCRIPTION
- handle `x86` and `arm64` like it is done for cuda package using `platform.machine()`
- set rpath in cray-mpich wrapper for mpich and gtl
- packages in jfrog have been updated with added platform suffix `*.x86_64.tar.gz` and `*.aarch64.tar.gz`.

Tested on clariden for mpich-gcc/nvhpc using osu_bw.


