### PR TITLE
update cray-mpich 8.1.18

### DIFF
--- a/stackinator/repo/packages/cray-gtl/package.py
+++ b/stackinator/repo/packages/cray-gtl/package.py
@@ -33,7 +33,7 @@ _versions = {
         "Linux-x86_64": "78072edfcb6cc24cfefab06e824111b5b2b839551235ece68cd154bec7936a24"
     },
     "8.1.18": {
-        "Linux-x86_64": "5ac6b0877fd0f6afaaf391fffef41daf4d3150edc3250721c9abd4ded6b58486"
+        "Linux-x86_64": "79c24203a27b67d3aa15ebaab6121e7e72e8a2be61622876179f694a7fb4399c"
     },
 }
 

--- a/stackinator/repo/packages/cray-mpich/package.py
+++ b/stackinator/repo/packages/cray-mpich/package.py
@@ -33,7 +33,7 @@ _versions = {
         "Linux-x86_64": "5fda115f356c26e5d9f8cc68fe578e954a70edd10ebf007182d945345886b61a"
     },
     "8.1.18": {
-        "Linux-x86_64": "45d519be217cea89c58893d25826b15d99183247d15ecee9c3f64913660d79c2"
+        "Linux-x86_64": "f7feafd204502d0dab449ff22da138c933ec22d7de3d5e30fbb9a62fc9cdf237"
     },
 }
 

--- a/stackinator/repo/packages/cray-pals/package.py
+++ b/stackinator/repo/packages/cray-pals/package.py
@@ -29,6 +29,9 @@ _versions = {
     "1.2.4": {
         "Linux-x86_64": "a253939585bad2bb9061b98be6e517f18bda0602ecfd38f75c734a01d12003f2"
     },
+    "1.2.0": {
+        "Linux-x86_64": "6f5c71aa4dd2f591b899ea693cae7a5319d859f69d8c46b7ee244fed8c094d10"
+    },
 }
 
 

--- a/stackinator/repo/packages/cray-pmi/package.py
+++ b/stackinator/repo/packages/cray-pmi/package.py
@@ -32,6 +32,9 @@ _versions = {
     "6.1.7": {
         "Linux-x86_64": "574b21bd6f8970521c2bc4f096aced896fec8b749f854272cc7bbb7130ae92d8"
     },
+    "6.0.17": {
+        "Linux-x86_64": "5f15cd577c6c082888fcf0f76f0f5a898ddfa32370e1c32ffe926912d4d4dad0"
+    },
 }
 
 


### PR DESCRIPTION
manually update packages for cray-mpich 8.1.18 using rpath in mpic++/fort wrappers