### PR TITLE
Support Grace-Hopper

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,7 +22,7 @@ jobs:
         black --check --verbose --exclude stackinator/repo stackinator unittests
     - name: isort
       run: |
-        isort --check --diff .
+        isort --check --skip stackinator/repo --diff .
     - name: flake8
       run: |
         flake8 --count --show-source --statistics .

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
         python -m pip install black flake8 isort mypy
     - name: Black
       run: |
-        black --check --verbose .
+        black --check --verbose --exclude=./stackinator/repo .
     - name: isort
       run: |
         isort --check --diff .

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
         python -m pip install black flake8 isort mypy
     - name: Black
       run: |
-        black --check --verbose --exclude=./stackinator/repo .
+        black --check --verbose --exclude stackinator/repo stackinator unittests
     - name: isort
       run: |
         isort --check --diff .

--- a/stackinator/repo/packages/aws-ofi-nccl/package.py
+++ b/stackinator/repo/packages/aws-ofi-nccl/package.py
@@ -1,0 +1,66 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class AwsOfiNccl(AutotoolsPackage):
+    """AWS OFI NCCL is a plug-in which enables EC2 developers to use
+    libfabric as a network provider while running NVIDIA's NCCL based
+    applications."""
+
+    homepage = "https://github.com/aws/aws-ofi-nccl"
+    git = "https://github.com/aws/aws-ofi-nccl.git"
+    url = "https://github.com/aws/aws-ofi-nccl.git"
+
+    maintainers("bvanessen")
+
+    version("master", branch="master")
+    version("v1.7.4",
+            sha256="cca529da330d3155ae1502c21365d62159254bca6bfc0482afd35e7eaa927090",
+            url="https://github.com/aws/aws-ofi-nccl/releases/download/v1.7.4-aws/aws-ofi-nccl-1.7.4-aws.tar.gz",
+    )
+
+    variant("trace", default=False, description="Enable printing trace messages")
+    variant("tests", default=False, description="Build tests")
+
+    depends_on("libfabric")
+    depends_on("cuda")
+    depends_on("nccl")
+    depends_on("mpi")
+    depends_on("hwloc")
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+
+    # To enable this plug-in to work with NCCL add it to the LD_LIBRARY_PATH
+    def setup_run_environment(self, env):
+        aws_ofi_nccl_home = self.spec.prefix
+        env.append_path("LD_LIBRARY_PATH", aws_ofi_nccl_home.lib)
+
+    # To enable this plug-in to work with NCCL add it to the LD_LIBRARY_PATH
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        aws_ofi_nccl_home = self.spec["aws-ofi-nccl"].prefix
+        env.append_path("LD_LIBRARY_PATH", aws_ofi_nccl_home.lib)
+
+    def configure_args(self):
+        spec = self.spec
+        args = []
+
+        # Always set configure's external paths to use the Spack
+        # provided dependencies
+        args.extend(
+            [
+                "--with-libfabric={0}".format(spec["libfabric"].prefix),
+                "--with-cuda={0}".format(spec["cuda"].prefix),
+                "--with-nccl={0}".format(spec["nccl"].prefix),
+                "--with-mpi={0}".format(spec["mpi"].prefix),
+            ]
+        )
+
+        args.extend(self.enable_or_disable("trace"))
+        args.extend(self.enable_or_disable("tests"))
+
+        return args

--- a/stackinator/repo/packages/cray-mpich/package.py
+++ b/stackinator/repo/packages/cray-mpich/package.py
@@ -11,7 +11,7 @@ from spack.package import *
 
 _versions = {
     "8.1.29": {
-        "Linux-aarch64": "6133ce31b20612a8152323d2d64211085a026ec62beacda4e8a2566d7b807605",
+        "Linux-aarch64": "9a99334ae81ff8f25c1c57e84ba989f12f4051ce1cc0a4aff8069a9a64321eab",
     },
     "8.1.28": {
         "Linux-aarch64": "dfd6c685adfbf070fe9d546d95b31e108ee7089a738447fa7326973a3e696e8d",
@@ -78,20 +78,20 @@ class CrayMpich(Package):
         "8.1.26",
         "8.1.27",
         "8.1.28",
-        "8.1.29",
     ]:
         with when("+cuda"):
             depends_on(f"cray-gtl@{ver} +cuda", type="link", when="@" + ver)
         with when("+rocm"):
             depends_on(f"cray-gtl@{ver} +rocm", type="link", when="@" + ver)
 
+    depends_on("cray-gtl@8.1.28+cuda", type="link", when="@8.1.29")
     depends_on("libfabric@1:", type="link")
 
     depends_on("cray-pmi", type="link")
 
     conflicts("%gcc@:7")
     conflicts("%gcc@:11", when="@8.1.28:")
-    conflicts("%nvhpc", when="@8.1.29")
+    conflicts("%gcc", when="@8.1.29")
 
     def setup_run_environment(self, env):
         env.set("MPICC", join_path(self.prefix.bin, "mpicc"))

--- a/stackinator/repo/packages/cuda/package.py
+++ b/stackinator/repo/packages/cuda/package.py
@@ -1,0 +1,695 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+import platform
+import re
+from glob import glob
+
+import llnl.util.tty as tty
+
+from spack.package import *
+
+# FIXME Remove hack for polymorphic versions
+# This package uses a ugly hack to be able to dispatch, given the same
+# version, to different binary packages based on the platform that is
+# running spack. See #13827 for context.
+# If you need to add a new version, please be aware that:
+#  - versions in the following dict are automatically added to the package
+#  - version tuple must be in the form (checksum, url)
+#  - checksum must be sha256
+#  - package key must be in the form '{os}-{arch}' where 'os' is in the
+#    format returned by platform.system() and 'arch' by platform.machine()
+
+preferred_ver = "11.8.0"
+_versions = {
+    "12.3.0": {
+        "Linux-aarch64": (
+            "9a8fb8acf46b88faf0d711bda3149e1706efbbae02fcb40ab72addfd0e9ce5df",
+            "https://developer.download.nvidia.com/compute/cuda/12.3.0/local_installers/cuda_12.3.0_545.23.06_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "7c13face3af64d6e1648d6e3101d31c8111e747143acb0077d973c1690820422",
+            "https://developer.download.nvidia.com/compute/cuda/12.3.0/local_installers/cuda_12.3.0_545.23.06_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "de15c04380ec35b194c07503bf434837bac5b427cf77b19a63962b1653d195d5",
+            "https://developer.download.nvidia.com/compute/cuda/12.3.0/local_installers/cuda_12.3.0_545.23.06_linux_ppc64le.run",
+        ),
+    },
+    "12.2.1": {
+        "Linux-aarch64": (
+            "a9ae6bd02684c7acfb229484368bf2691d592767ce1aed10ae9aed92c81b9f09",
+            "https://developer.download.nvidia.com/compute/cuda/12.2.1/local_installers/cuda_12.2.1_535.86.10_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "c51e814eaa756160a73289b1f35880cc38c18e1ddedc87f46f7ff0d1696bdb95",
+            "https://developer.download.nvidia.com/compute/cuda/12.2.1/local_installers/cuda_12.2.1_535.86.10_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "8f1aa60cc1e14fd7853eeecd53a78b7dfb2b2da0512a312cc35e4f5b79454f94",
+            "https://developer.download.nvidia.com/compute/cuda/12.2.1/local_installers/cuda_12.2.1_535.86.10_linux_ppc64le.run",
+        ),
+    },
+    "12.2.0": {
+        "Linux-aarch64": (
+            "9c90d79bb63952cd30f1f57f9f8fe11e7a8967bba6f824df45d3464b5d37e5d8",
+            "https://developer.download.nvidia.com/compute/cuda/12.2.0/local_installers/cuda_12.2.0_535.54.03_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "ecf3d2afadcbac029f0f4505785810d52d006e4b87ba79ff3f984336a2bbf518",
+            "https://developer.download.nvidia.com/compute/cuda/12.2.0/local_installers/cuda_12.2.0_535.54.03_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "f7b5fde5f727b51c380c6199200d0525e8585475944ff8ad2791d06734f54230",
+            "https://developer.download.nvidia.com/compute/cuda/12.2.0/local_installers/cuda_12.2.0_535.54.03_linux_ppc64le.run",
+        ),
+    },
+    "12.1.1": {
+        "Linux-aarch64": (
+            "45ea4cd860f0a26d3db8ce032530f2ee0b55abdd587545213d395a73623b4278",
+            "https://developer.download.nvidia.com/compute/cuda/12.1.1/local_installers/cuda_12.1.1_530.30.02_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "d74022d41d80105319dfa21beea39b77a5b9919539c0487a05caaf2446d6a70e",
+            "https://developer.download.nvidia.com/compute/cuda/12.1.1/local_installers/cuda_12.1.1_530.30.02_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "c5950381f2c01fd52692372fc8e51d599e940ada2af2c82c3cc854ecff933eae",
+            "https://developer.download.nvidia.com/compute/cuda/12.1.1/local_installers/cuda_12.1.1_530.30.02_linux_ppc64le.run",
+        ),
+    },
+    "12.1.0": {
+        "Linux-aarch64": (
+            "1d0dd884f5257c12471dc455dc1a4aee8d620191737c0b2e40f016d8adc9d009",
+            "https://developer.download.nvidia.com/compute/cuda/12.1.0/local_installers/cuda_12.1.0_530.30.02_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "68699036c12d71adb9ad2799dce2ff070270fab4488b90920b9756ab3f52c41c",
+            "https://developer.download.nvidia.com/compute/cuda/12.1.0/local_installers/cuda_12.1.0_530.30.02_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "8d75bd9da953a51062b89b8c752cffcf02b02c85cb461291d354ac2cffb2da48",
+            "https://developer.download.nvidia.com/compute/cuda/12.1.0/local_installers/cuda_12.1.0_530.30.02_linux_ppc64le.run",
+        ),
+    },
+    "12.0.1": {
+        "Linux-aarch64": (
+            "835270a8db419b9dbaefc1bab8fe5caf6f2caf381975c4b0d35cc0718c26074a",
+            "https://developer.download.nvidia.com/compute/cuda/12.0.1/local_installers/cuda_12.0.1_525.85.12_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "1b205a06272f1463f477276fdab903f3f666917c068e520738001e69c7a1875b",
+            "https://developer.download.nvidia.com/compute/cuda/12.0.1/local_installers/cuda_12.0.1_525.85.12_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "1e81040223c25fd72895a1348e32463d7d0f5a7e74b5d2ace897220cb6d4d849",
+            "https://developer.download.nvidia.com/compute/cuda/12.0.1/local_installers/cuda_12.0.1_525.85.12_linux_ppc64le.run",
+        ),
+    },
+    "12.0.0": {
+        "Linux-aarch64": (
+            "cd13e9c65d4c8f895a968706f46064d536be09f9706bce081cc864b7e4fa4544",
+            "https://developer.download.nvidia.com/compute/cuda/12.0.0/local_installers/cuda_12.0.0_525.60.13_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "905e9b9516900839fb76064719db752439f38b8cb730b49335d8bd53ddfad392",
+            "https://developer.download.nvidia.com/compute/cuda/12.0.0/local_installers/cuda_12.0.0_525.60.13_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "117fe045c71668e45d41c6119b6f27875370c78e33fc56795b6fe014c796ec60",
+            "https://developer.download.nvidia.com/compute/cuda/12.0.0/local_installers/cuda_12.0.0_525.60.13_linux_ppc64le.run",
+        ),
+    },
+    "11.8.0": {
+        "Linux-aarch64": (
+            "e6e9a8d31163c9776b5e313fd7590877c5684e1ecddee741154f95704d4ed27c",
+            "https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_520.61.05_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "9223c4af3aebe4a7bbed9abd9b163b03a1b34b855fbc2b4a0d1b706ac09a5a16",
+            "https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_520.61.05_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "f917fb7617033223938543ad3ae923190d99507acc08a399d752a2868e87349d",
+            "https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_520.61.05_linux_ppc64le.run",
+        ),
+    },
+    "11.7.1": {
+        "Linux-aarch64": (
+            "1607b98c30cb8efa52b9c8f564ec92d26ee1922cb677740aafacce313e544ecd",
+            "https://developer.download.nvidia.com/compute/cuda/11.7.1/local_installers/cuda_11.7.1_515.65.01_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "52286a29706549b7d0feeb0e7e3eca1b15287c436a69fa880ad385b1be3e04db",
+            "https://developer.download.nvidia.com/compute/cuda/11.7.1/local_installers/cuda_11.7.1_515.65.01_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "f59fc381cbd903da55bfea9f81534bd4d20e3db716c332be3d2c4804efc2ec6b",
+            "https://developer.download.nvidia.com/compute/cuda/11.7.1/local_installers/cuda_11.7.1_515.65.01_linux_ppc64le.run",
+        ),
+    },
+    "11.7.0": {
+        "Linux-aarch64": (
+            "e777839a618ca9a3d5ad42ded43a1b6392af2321a7327635a4afcc986876a21b",
+            "https://developer.download.nvidia.com/compute/cuda/11.7.0/local_installers/cuda_11.7.0_515.43.04_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "087fdfcbba1f79543b1f78e43a8dfdac5f6db242d042dde820e16dc185892f26",
+            "https://developer.download.nvidia.com/compute/cuda/11.7.0/local_installers/cuda_11.7.0_515.43.04_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "74a507ac54067c258e6b7c9063c98d411116ecc5c5397b1f6e6a999e86dff08a",
+            "https://developer.download.nvidia.com/compute/cuda/11.7.0/local_installers/cuda_11.7.0_515.43.04_linux_ppc64le.run",
+        ),
+    },
+    "11.6.2": {
+        "Linux-aarch64": (
+            "b20c014c6bba36b13c50da167ad42e9bd1cea24f3b6297b495ea129c0889f36e",
+            "https://developer.download.nvidia.com/compute/cuda/11.6.2/local_installers/cuda_11.6.2_510.47.03_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "99b7a73dcc52a52cef4c1fceb4a60c3015ac9b6404082c1677d9efdaba1d4593",
+            "https://developer.download.nvidia.com/compute/cuda/11.6.2/local_installers/cuda_11.6.2_510.47.03_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "869232ff8dbf295a71609738ac9e1b0079ca75597b427f1c026f42b36896afe8",
+            "https://developer.download.nvidia.com/compute/cuda/11.6.2/local_installers/cuda_11.6.2_510.47.03_linux_ppc64le.run",
+        ),
+    },
+    "11.6.1": {
+        "Linux-aarch64": (
+            "80586b003d58030004d465f5331dc69ee26c95a29516fb2488ff10f034139cb2",
+            "https://developer.download.nvidia.com/compute/cuda/11.6.1/local_installers/cuda_11.6.1_510.47.03_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "ab219afce00b74200113269866fbff75ead037bcfc23551a8338c2684c984d7e",
+            "https://developer.download.nvidia.com/compute/cuda/11.6.1/local_installers/cuda_11.6.1_510.47.03_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "ef762efbc00b67d572823c6ec338cc2c0cf0c096f41e6bce18e8d4501f260956",
+            "https://developer.download.nvidia.com/compute/cuda/11.6.1/local_installers/cuda_11.6.1_510.47.03_linux_ppc64le.run",
+        ),
+    },
+    "11.6.0": {
+        "Linux-aarch64": (
+            "5898579f5e59b708520883cb161089f5e4f3426158d1e9f973c49d224085d1d2",
+            "https://developer.download.nvidia.com/compute/cuda/11.6.0/local_installers/cuda_11.6.0_510.39.01_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "1783da6d63970786040980b57fa3cb6420142159fc7d0e66f8f05c4905d98c83",
+            "https://developer.download.nvidia.com/compute/cuda/11.6.0/local_installers/cuda_11.6.0_510.39.01_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "c86b866a42baf59ddc6f1f4a79e6d77213c90749e77e574f0e0d796a749ab7d0",
+            "https://developer.download.nvidia.com/compute/cuda/11.6.0/local_installers/cuda_11.6.0_510.39.01_linux_ppc64le.run",
+        ),
+    },
+    "11.5.2": {
+        "Linux-aarch64": (
+            "31337c8bdc224fa1bd07bc4b6a745798392428118cc8ea0fa4446ee4ad47dd30",
+            "https://developer.download.nvidia.com/compute/cuda/11.5.2/local_installers/cuda_11.5.2_495.29.05_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "74959abf02bcba526f0a3aae322c7641b25da040ccd6236d07038f81997b73a6",
+            "https://developer.download.nvidia.com/compute/cuda/11.5.2/local_installers/cuda_11.5.2_495.29.05_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "45c468f430436b3e95d5e485a6ba0ec1fa2b23dc6c551c1307b79996ecf0a7ed",
+            "https://developer.download.nvidia.com/compute/cuda/11.5.2/local_installers/cuda_11.5.2_495.29.05_linux_ppc64le.run",
+        ),
+    },
+    "11.5.1": {
+        "Linux-aarch64": (
+            "73e1d0e97c7fa686efe7e00fb1e5f179372c4eec8e14d4f44ab58d5f6cf57f63",
+            "https://developer.download.nvidia.com/compute/cuda/11.5.1/local_installers/cuda_11.5.1_495.29.05_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "60bea2fc0fac95574015f865355afbf599422ec2c85554f5f052b292711a4bca",
+            "https://developer.download.nvidia.com/compute/cuda/11.5.1/local_installers/cuda_11.5.1_495.29.05_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "9e0e494d945634fe8ad3e12d7b91806aa4220ed27487bb211030d651b27c67a9",
+            "https://developer.download.nvidia.com/compute/cuda/11.5.1/local_installers/cuda_11.5.1_495.29.05_linux_ppc64le.run",
+        ),
+    },
+    "11.5.0": {
+        "Linux-aarch64": (
+            "6ea9d520cc956cc751a5ac54f4acc39109627f4e614dd0b1a82cc86f2aa7d8c4",
+            "https://developer.download.nvidia.com/compute/cuda/11.5.0/local_installers/cuda_11.5.0_495.29.05_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "ae0a1693d9497cf3d81e6948943e3794636900db71c98d58eefdacaf7f1a1e4c",
+            "https://developer.download.nvidia.com/compute/cuda/11.5.0/local_installers/cuda_11.5.0_495.29.05_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "95baefdc5adf165189407b119861ffb2e9800fd94d7fc81d10fb81ed36dc12db",
+            "https://developer.download.nvidia.com/compute/cuda/11.5.0/local_installers/cuda_11.5.0_495.29.05_linux_ppc64le.run",
+        ),
+    },
+    "11.4.4": {
+        "Linux-aarch64": (
+            "c5c08531e48e8fdc2704fa1c1f7195f2c7edd2ee10a466d0e24d05b77d109435",
+            "https://developer.download.nvidia.com/compute/cuda/11.4.4/local_installers/cuda_11.4.4_470.82.01_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "44545a7abb4b66dfc201dcad787b5e8352e5b7ddf3e3cc5b2e9177af419c25c8",
+            "https://developer.download.nvidia.com/compute/cuda/11.4.4/local_installers/cuda_11.4.4_470.82.01_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "c71cd4e6c05fde11c0485369a73e7f356080e7a18f0e3ad7244e8fc03a9dd3e2",
+            "https://developer.download.nvidia.com/compute/cuda/11.4.4/local_installers/cuda_11.4.4_470.82.01_linux_ppc64le.run",
+        ),
+    },
+    "11.4.3": {
+        "Linux-aarch64": (
+            "e02db34a487ea3de3eec9db80efd09f12eb69d55aca686cecaeae96a9747b1d4",
+            "https://developer.download.nvidia.com/compute/cuda/11.4.3/local_installers/cuda_11.4.3_470.82.01_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "749183821ffc051e123f12ebdeb171b263d55b86f0dd7c8f23611db1802d6c37",
+            "https://developer.download.nvidia.com/compute/cuda/11.4.3/local_installers/cuda_11.4.3_470.82.01_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "08f29cc3ed0b3b82dd9b007186237be2352bb552f99230c450a25e768f5754ee",
+            "https://developer.download.nvidia.com/compute/cuda/11.4.3/local_installers/cuda_11.4.3_470.82.01_linux_ppc64le.run",
+        ),
+    },
+    "11.4.2": {
+        "Linux-aarch64": (
+            "f2c4a52e06329606c8dfb7c5ea3f4cb4c0b28f9d3fdffeeb734fcc98daf580d8",
+            "https://developer.download.nvidia.com/compute/cuda/11.4.2/local_installers/cuda_11.4.2_470.57.02_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "bbd87ca0e913f837454a796367473513cddef555082e4d86ed9a38659cc81f0a",
+            "https://developer.download.nvidia.com/compute/cuda/11.4.2/local_installers/cuda_11.4.2_470.57.02_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "a917c2e53dc13fdda7def71fd40920bf3809d5a2caa3e9acfe377fb9fb22f12d",
+            "https://developer.download.nvidia.com/compute/cuda/11.4.2/local_installers/cuda_11.4.2_470.57.02_linux_ppc64le.run",
+        ),
+    },
+    "11.4.1": {
+        "Linux-aarch64": (
+            "8efa725a41dfd3c0c0f453c2dd535d149154102bf2b791718859417b4f84f922",
+            "https://developer.download.nvidia.com/compute/cuda/11.4.1/local_installers/cuda_11.4.1_470.57.02_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "dd6c339a719989d2518f5d54eeac1ed707d0673f8664ba0c4d4b2af7c3ba0005",
+            "https://developer.download.nvidia.com/compute/cuda/11.4.1/local_installers/cuda_11.4.1_470.57.02_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "dd92ca04f76ad938da3480e2901c0e52dbff6028ada63c09071ed9e3055dc361",
+            "https://developer.download.nvidia.com/compute/cuda/11.4.1/local_installers/cuda_11.4.1_470.57.02_linux_ppc64le.run",
+        ),
+    },
+    "11.4.0": {
+        "Linux-aarch64": (
+            "f0c8e80d98a601ddca031b6764459984366008c7d3847e7c7f99b36bd4438e3c",
+            "https://developer.download.nvidia.com/compute/cuda/11.4.0/local_installers/cuda_11.4.0_470.42.01_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "d219db30f7415a115a4ea22bdbb5984b0a18f7f891cad6074c5da45d223aaa4b",
+            "https://developer.download.nvidia.com/compute/cuda/11.4.0/local_installers/cuda_11.4.0_470.42.01_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "6eb2fd0d9d5bc39fb243b5e1789ff827f325d098cd1fbb828a0499552b9544cc",
+            "https://developer.download.nvidia.com/compute/cuda/11.4.0/local_installers/cuda_11.4.0_470.42.01_linux_ppc64le.run",
+        ),
+    },
+    "11.3.1": {
+        "Linux-aarch64": (
+            "39990d3da88b21289ac20850bc183f0b66275f32e1f562b551c05843bf506e4c",
+            "https://developer.download.nvidia.com/compute/cuda/11.3.1/local_installers/cuda_11.3.1_465.19.01_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "ad93ea98efced35855c58d3a0fc326377c60917cb3e8c017d3e6d88819bf2934",
+            "https://developer.download.nvidia.com/compute/cuda/11.3.1/local_installers/cuda_11.3.1_465.19.01_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "220f2c10a21500d62b03c6848c1659ebb3a8e10dc0915ab87b86b397058407c5",
+            "https://developer.download.nvidia.com/compute/cuda/11.3.1/local_installers/cuda_11.3.1_465.19.01_linux_ppc64le.run",
+        ),
+    },
+    "11.3.0": {
+        "Linux-aarch64": (
+            "f7b284cf055fcf18be9a9aa216e3c7968d3e011446eb0c7200a3353c223ce718",
+            "https://developer.download.nvidia.com/compute/cuda/11.3.0/local_installers/cuda_11.3.0_465.19.01_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "262da7f77db177b153a6b70b5812210f3f72f00eb608ab9cf2a4582328c4bf5c",
+            "https://developer.download.nvidia.com/compute/cuda/11.3.0/local_installers/cuda_11.3.0_465.19.01_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "c0010107933b575a87e27b1293e5dc32b74201486f4ae2f4c8695ea727d22857",
+            "https://developer.download.nvidia.com/compute/cuda/11.3.0/local_installers/cuda_11.3.0_465.19.01_linux_ppc64le.run",
+        ),
+    },
+    "11.2.2": {
+        "Linux-aarch64": (
+            "2f915ad631331eebdafaabd971723a60290ae8bb090d771075b9e6a0b28cbae6",
+            "https://developer.download.nvidia.com/compute/cuda/11.2.2/local_installers/cuda_11.2.2_460.32.03_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "0a2e477224af7f6003b49edfd2bfee07667a8148fe3627cfd2765f6ad72fa19d",
+            "https://developer.download.nvidia.com/compute/cuda/11.2.2/local_installers/cuda_11.2.2_460.32.03_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "2304ec235fe5d1f8bf75f00dc2c2d11473759dc23428dbbd5fb5040bc8c757e3",
+            "https://developer.download.nvidia.com/compute/cuda/11.2.2/local_installers/cuda_11.2.2_460.32.03_linux_ppc64le.run",
+        ),
+    },
+    "11.2.1": {
+        "Linux-aarch64": (
+            "4b322fa6477d1a2cd2f2f526fa520c0f90bef2c264ef8435cb016bebb5456c5e",
+            "https://developer.download.nvidia.com/compute/cuda/11.2.1/local_installers/cuda_11.2.1_460.32.03_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "1da98cb897cc5f58a7445a4a66ca4f6926867706cb3af58a669cdcd8dc3d17c8",
+            "https://developer.download.nvidia.com/compute/cuda/11.2.1/local_installers/cuda_11.2.1_460.32.03_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "b3e8b6cd76872deb3acd050d32e197bc1c655e142b169070f0f9753680461a3f",
+            "https://developer.download.nvidia.com/compute/cuda/11.2.1/local_installers/cuda_11.2.1_460.32.03_linux_ppc64le.run",
+        ),
+    },
+    "11.2.0": {
+        "Linux-aarch64": (
+            "c11dc274660e9b47b0f25ca66861a7406246a7191f1b04d0710515fcac0fa6cd",
+            "https://developer.download.nvidia.com/compute/cuda/11.2.0/local_installers/cuda_11.2.0_460.27.04_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "9c50283241ac325d3085289ed9b9c170531369de41165ce271352d4a898cbdce",
+            "https://developer.download.nvidia.com/compute/cuda/11.2.0/local_installers/cuda_11.2.0_460.27.04_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "adc3267df5dbfdaf51cb4c9b227ba6bfd979a39d9b4136bba0eba6b1dd2a2731",
+            "https://developer.download.nvidia.com/compute/cuda/11.2.0/local_installers/cuda_11.2.0_460.27.04_linux_ppc64le.run",
+        ),
+    },
+    "11.1.1": {
+        "Linux-aarch64": (
+            "9ab1dbafba205c06bea8c88e38cdadb3038af19cb56e7b3ba734d3d7a84b8f02",
+            "https://developer.download.nvidia.com/compute/cuda/11.1.1/local_installers/cuda_11.1.1_455.32.00_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "3eae6727086024925ebbcef3e9a45ad379d8490768fd00f9c2d8b6fd9cd8dd8f",
+            "https://developer.download.nvidia.com/compute/cuda/11.1.1/local_installers/cuda_11.1.1_455.32.00_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "023e571fe26ee829c98138dfc305a92279854aac7d184d255fd58c06c6af3c17",
+            "https://developer.download.nvidia.com/compute/cuda/11.1.1/local_installers/cuda_11.1.1_455.32.00_linux_ppc64le.run",
+        ),
+    },
+    "11.1.0": {
+        "Linux-aarch64": (
+            "878cbd36c5897468ef28f02da50b2f546af0434a8a89d1c724a4d2013d6aa993",
+            "https://developer.download.nvidia.com/compute/cuda/11.1.0/local_installers/cuda_11.1.0_455.23.05_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "858cbab091fde94556a249b9580fadff55a46eafbcb4d4a741d2dcd358ab94a5",
+            "https://developer.download.nvidia.com/compute/cuda/11.1.0/local_installers/cuda_11.1.0_455.23.05_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "a561e6f7f659bc4100e4713523b0b8aad6b36aa77fac847f6423e7780c750064",
+            "https://developer.download.nvidia.com/compute/cuda/11.1.0/local_installers/cuda_11.1.0_455.23.05_linux_ppc64le.run",
+        ),
+    },
+    "11.0.3": {
+        "Linux-aarch64": (
+            "1e24f61f79c1043aa3d1d126ff6158daa03a62a51b5195a2ed5fbe75c3b718f3",
+            "https://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda_11.0.3_450.51.06_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "b079c4e408adf88c3f1ffb8418a97dc4227c37935676b4bf4ca0beec6c328cc0",
+            "https://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda_11.0.3_450.51.06_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "4775b21df004b1433bafff9b48a324075c008509f4c0fe28cd060d042d2e0794",
+            "https://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda_11.0.3_450.51.06_linux_ppc64le.run",
+        ),
+    },
+    "11.0.2": {
+        "Linux-aarch64": (
+            "23851e30f7c47a1baad92891abde0adbc783de5962c7480b9725198ceacda4a0",
+            "https://developer.download.nvidia.com/compute/cuda/11.0.2/local_installers/cuda_11.0.2_450.51.05_linux_sbsa.run",
+        ),
+        "Linux-x86_64": (
+            "48247ada0e3f106051029ae8f70fbd0c238040f58b0880e55026374a959a69c1",
+            "https://developer.download.nvidia.com/compute/cuda/11.0.2/local_installers/cuda_11.0.2_450.51.05_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "db06d0f3fbf6f7aa1f106fc921ad1c86162210a26e8cb65b171c5240a3bf75da",
+            "https://developer.download.nvidia.com/compute/cuda/11.0.2/local_installers/cuda_11.0.2_450.51.05_linux_ppc64le.run",
+        ),
+    },
+    "10.2.89": {
+        "Linux-x86_64": (
+            "560d07fdcf4a46717f2242948cd4f92c5f9b6fc7eae10dd996614da913d5ca11",
+            "https://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda_10.2.89_440.33.01_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "5227774fcb8b10bd2d8714f0a716a75d7a2df240a9f2a49beb76710b1c0fc619",
+            "https://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda_10.2.89_440.33.01_linux_ppc64le.run",
+        ),
+    },
+    "10.1.243": {
+        "Linux-x86_64": (
+            "e7c22dc21278eb1b82f34a60ad7640b41ad3943d929bebda3008b72536855d31",
+            "https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda_10.1.243_418.87.00_linux.run",
+        ),
+        "Linux-ppc64le": (
+            "b198002eef010bab9e745ae98e47567c955d00cf34cc8f8d2f0a6feb810523bf",
+            "https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda_10.1.243_418.87.00_linux_ppc64le.run",
+        ),
+    },
+    "10.0.130": {
+        "Linux-x86_64": (
+            "92351f0e4346694d0fcb4ea1539856c9eb82060c25654463bfd8574ec35ee39a",
+            "https://developer.nvidia.com/compute/cuda/10.0/Prod/local_installers/cuda_10.0.130_410.48_linux",
+        )
+    },
+    "9.2.88": {
+        "Linux-x86_64": (
+            "8d02cc2a82f35b456d447df463148ac4cc823891be8820948109ad6186f2667c",
+            "https://developer.nvidia.com/compute/cuda/9.2/Prod/local_installers/cuda_9.2.88_396.26_linux",
+        )
+    },
+    "9.1.85": {
+        "Linux-x86_64": (
+            "8496c72b16fee61889f9281449b5d633d0b358b46579175c275d85c9205fe953",
+            "https://developer.nvidia.com/compute/cuda/9.1/Prod/local_installers/cuda_9.1.85_387.26_linux",
+        )
+    },
+    "9.0.176": {
+        "Linux-x86_64": (
+            "96863423feaa50b5c1c5e1b9ec537ef7ba77576a3986652351ae43e66bcd080c",
+            "https://developer.nvidia.com/compute/cuda/9.0/Prod/local_installers/cuda_9.0.176_384.81_linux-run",
+        )
+    },
+    "8.0.61": {
+        "Linux-x86_64": (
+            "9ceca9c2397f841024e03410bfd6eabfd72b384256fbed1c1e4834b5b0ce9dc4",
+            "https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/cuda_8.0.61_375.26_linux-run",
+        )
+    },
+    "8.0.44": {
+        "Linux-x86_64": (
+            "64dc4ab867261a0d690735c46d7cc9fc60d989da0d69dc04d1714e409cacbdf0",
+            "https://developer.nvidia.com/compute/cuda/8.0/prod/local_installers/cuda_8.0.44_linux-run",
+        )
+    },
+    "7.5.18": {
+        "Linux-x86_64": (
+            "08411d536741075131a1858a68615b8b73c51988e616e83b835e4632eea75eec",
+            "https://developer.download.nvidia.com/compute/cuda/7.5/Prod/local_installers/cuda_7.5.18_linux.run",
+        )
+    },
+    "6.5.14": {
+        "Linux-x86_64": (
+            "f3e527f34f317314fe8fcd8c85f10560729069298c0f73105ba89225db69da48",
+            "https://developer.download.nvidia.com/compute/cuda/6_5/rel/installers/cuda_6.5.14_linux_64.run",
+        )
+    },
+    "6.0.37": {
+        "Linux-x86_64": (
+            "991e436c7a6c94ec67cf44204d136adfef87baa3ded270544fa211179779bc40",
+            "https://developer.download.nvidia.com/compute/cuda/6_0/rel/installers/cuda_6.0.37_linux_64.run",
+        )
+    },
+}
+
+
+class Cuda(Package):
+    """CUDA is a parallel computing platform and programming model invented
+    by NVIDIA. It enables dramatic increases in computing performance by
+    harnessing the power of the graphics processing unit (GPU).
+
+    Note: This package does not currently install the drivers necessary
+    to run CUDA. These will need to be installed manually. See:
+    https://docs.nvidia.com/cuda/ for details."""
+
+    homepage = "https://developer.nvidia.com/cuda-zone"
+
+    maintainers("ax3l", "Rombur")
+    executables = ["^nvcc$"]
+
+    skip_version_audit = ["platform=darwin"]
+
+    for ver, packages in _versions.items():
+        key = "{0}-{1}".format(platform.system(), platform.machine())
+        pkg = packages.get(key)
+        if pkg:
+            if ver == preferred_ver:
+                version(ver, sha256=pkg[0], url=pkg[1], expand=False, preferred=True)
+            else:
+                version(ver, sha256=pkg[0], url=pkg[1], expand=False)
+
+    # macOS Mojave drops NVIDIA graphics card support -- official NVIDIA
+    # drivers do not exist for Mojave. See
+    # https://devtalk.nvidia.com/default/topic/1043070/announcements/faq-about-macos-10-14-mojave-nvidia-drivers/
+    # Note that a CUDA Toolkit installer does exist for macOS Mojave at
+    # https://developer.nvidia.com/compute/cuda/10.1/Prod1/local_installers/cuda_10.1.168_mac.dmg,
+    # but support for Mojave is dropped in later versions, and none of the
+    # macOS NVIDIA drivers at
+    # https://www.nvidia.com/en-us/drivers/cuda/mac-driver-archive/ mention
+    # Mojave support -- only macOS High Sierra 10.13 is supported.
+    conflicts("arch=darwin-mojave-x86_64")
+
+    variant(
+        "dev", default=False, description="Enable development dependencies, i.e to use cuda-gdb"
+    )
+    variant(
+        "allow-unsupported-compilers",
+        default=False,
+        sticky=True,
+        description="Allow unsupported host compiler and CUDA version combinations",
+    )
+
+    depends_on("libxml2", when="@10.1.243:")
+    # cuda-gdb needed libncurses.so.5 before 11.4.0
+    # see https://docs.nvidia.com/cuda/archive/11.3.1/cuda-gdb/index.html#common-issues-oss
+    # see https://docs.nvidia.com/cuda/archive/11.4.0/cuda-gdb/index.html#release-notes
+    depends_on("ncurses abi=5", type="run", when="@:11.3.99+dev")
+
+    provides("opencl@:1.2", when="@7:")
+    provides("opencl@:1.1", when="@:6")
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)("--version", output=str, error=str)
+        match = re.search(r"Cuda compilation tools, release .*?, V(\S+)", output)
+        return match.group(1) if match else None
+
+    def setup_build_environment(self, env):
+        if self.spec.satisfies("@:8.0.61"):
+            # Perl 5.26 removed current directory from module search path,
+            # CUDA 9 has a fix for this, but CUDA 8 and lower don't.
+            env.append_path("PERL5LIB", self.stage.source_path)
+
+        if self.spec.satisfies("@10.1.243:"):
+            libxml2_home = self.spec["libxml2"].prefix
+            env.set("LIBXML2HOME", libxml2_home)
+            env.append_path("LD_LIBRARY_PATH", libxml2_home.lib)
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.set("CUDAHOSTCXX", dependent_spec.package.compiler.cxx)
+        env.set("CUDA_HOME", self.prefix)
+        env.set("NVHPC_CUDA_HOME", self.prefix)
+
+    @property
+    def cmake_prefix_paths(self):
+        cmake_prefix_paths = [self.prefix]
+        if self.spec.satisfies("target=x86_64:"):
+            cub_path = self.prefix.targets + "/x86_64-linux/lib/cmake"
+            cmake_prefix_paths.append(cub_path)
+        return cmake_prefix_paths
+
+    def setup_run_environment(self, env):
+        env.set("CUDA_HOME", self.prefix)
+        env.set("NVHPC_CUDA_HOME", self.prefix)
+
+    def install(self, spec, prefix):
+        if os.path.exists("/tmp/cuda-installer.log"):
+            try:
+                os.remove("/tmp/cuda-installer.log")
+            except OSError:
+                if spec.satisfies("@10.1:"):
+                    tty.die(
+                        "The cuda installer will segfault due to the "
+                        "presence of /tmp/cuda-installer.log "
+                        "please remove the file and try again "
+                    )
+        runfile = glob(join_path(self.stage.source_path, "cuda*_linux*"))[0]
+
+        # Note: NVIDIA does not officially support many newer versions of
+        # compilers.  For example, on CentOS 6, you must use GCC 4.4.7 or
+        # older. See:
+        # http://docs.nvidia.com/cuda/cuda-installation-guide-linux/#system-requirements
+        # https://gist.github.com/ax3l/9489132
+        # for details.
+
+        # CUDA 10.1 on ppc64le fails to copy some files, the workaround is adapted from
+        # https://forums.developer.nvidia.com/t/cuda-10-1-243-10-1-update-2-ppc64le-run-file-installation-issue/82433
+        # See also #21170
+        if spec.satisfies("@10.1.243") and platform.machine() == "ppc64le":
+            includedir = "targets/ppc64le-linux/include"
+            os.makedirs(os.path.join(prefix, includedir))
+            os.makedirs(os.path.join(prefix, "src"))
+            os.symlink(includedir, os.path.join(prefix, "include"))
+
+        install_shell = which("sh")
+
+        if self.spec.satisfies("@:8.0.61"):
+            # Perl 5.26 removed current directory from module search path.
+            # We are addressing this by exporting `PERL5LIB` earlier, but for some
+            # reason, it is not enough. One more file needs to be extracted before
+            # running the actual installer. This solution is one of the commonly
+            # found on the Internet, when people try to install CUDA <= 8 manually.
+            # For example: https://askubuntu.com/a/1087842
+            arguments = [runfile, "--tar", "mxvf", "./InstallUtils.pm"]
+            install_shell(*arguments)
+
+        # CUDA 10.1+ has different cmdline options for the installer
+        arguments = [
+            runfile,  # the install script
+            "--silent",  # disable interactive prompts
+            "--override",  # override compiler version checks
+            "--toolkit",  # install CUDA Toolkit
+        ]
+
+        if spec.satisfies("@7:"):
+            # use stage dir instead of /tmp
+            mkdir(join_path(self.stage.path, "tmp"))
+            arguments.append("--tmpdir=%s" % join_path(self.stage.path, "tmp"))
+
+        if spec.satisfies("@10.1:"):
+            arguments.append("--installpath=%s" % prefix)  # Where to install
+        else:
+            arguments.append("--verbose")  # Verbose log file
+            arguments.append("--toolkitpath=%s" % prefix)  # Where to install
+
+        install_shell(*arguments)
+
+        try:
+            os.remove("/tmp/cuda-installer.log")
+        except OSError:
+            pass
+
+    @property
+    def libs(self):
+        libs = find_libraries("libcudart", root=self.prefix, shared=True, recursive=True)
+
+        filtered_libs = []
+        # CUDA 10.0 provides Compatability libraries for running newer versions
+        # of CUDA with older drivers. These do not work with newer drivers.
+        for lib in libs:
+            parts = lib.split(os.sep)
+            if "compat" not in parts and "stubs" not in parts:
+                filtered_libs.append(lib)
+        return LibraryList(filtered_libs)
+
+    # Avoid binding stub libraries by absolute path
+    non_bindable_shared_objects = ["stubs"]

--- a/stackinator/repo/packages/nvhpc/package.py
+++ b/stackinator/repo/packages/nvhpc/package.py
@@ -26,6 +26,10 @@ _versions = {
             "8d2aafa8769115191708e41e63c647e1c975c241ce4bf6a0badf805f0f5edf1c",
             "https://developer.download.nvidia.com/hpc-sdk/24.1/nvhpc_2024_241_Linux_aarch64_cuda_12.3.tar.gz",
         ),
+        "Linux-x86_64": (
+            "91cdc6f327881f14119e8b6e884d544aafab01c3d569b61831e259c91b4530fc",
+            "https://developer.download.nvidia.com/hpc-sdk/24.1/nvhpc_2024_241_Linux_x86_64_cuda_12.3.tar.gz",
+        ),
     },
     "23.11": {
         "Linux-aarch64": (

--- a/stackinator/repo/packages/nvhpc/package.py
+++ b/stackinator/repo/packages/nvhpc/package.py
@@ -1,0 +1,527 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+#
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+
+import platform
+
+from spack.package import *
+from spack.util.prefix import Prefix
+
+# FIXME Remove hack for polymorphic versions
+# This package uses a ugly hack to be able to dispatch, given the same
+# version, to different binary packages based on the platform that is
+# running spack. See #13827 for context.
+# If you need to add a new version, please be aware that:
+#  - versions in the following dict are automatically added to the package
+#  - version tuple must be in the form (checksum, url)
+#  - checksum must be sha256
+#  - package key must be in the form '{os}-{arch}' where 'os' is in the
+#    format returned by platform.system() and 'arch' by platform.machine()
+_versions = {
+    "24.1": {
+        "Linux-aarch64": (
+            "8d2aafa8769115191708e41e63c647e1c975c241ce4bf6a0badf805f0f5edf1c",
+            "https://developer.download.nvidia.com/hpc-sdk/24.1/nvhpc_2024_241_Linux_aarch64_cuda_12.3.tar.gz",
+        ),
+    },
+    "23.11": {
+        "Linux-aarch64": (
+            "cf744498d1d74ba0af4294388706644ad3669eb0cacea3b69e23739afa2806a0",
+            "https://developer.download.nvidia.com/hpc-sdk/23.11/nvhpc_2023_2311_Linux_aarch64_cuda_multi.tar.gz",
+        ),
+        "Linux-ppc64le": (
+            "b08591438bd0802d4c7c78e7c5bc36383a59591b8c2fa8aed5c4b87b24f7bfbb",
+            "https://developer.download.nvidia.com/hpc-sdk/23.11/nvhpc_2023_2311_Linux_ppc64le_cuda_multi.tar.gz",
+        ),
+        "Linux-x86_64": (
+            "33483a069a911f9309cd53859ab90d2778fb176df906e9e8d2bd55f45eeec400",
+            "https://developer.download.nvidia.com/hpc-sdk/23.11/nvhpc_2023_2311_Linux_x86_64_cuda_multi.tar.gz",
+        ),
+    },
+    "23.9": {
+        "Linux-aarch64": (
+            "dd32ae4233438adb71b2b4f8891f04802fdf90f67036ecf18bfde1b6043a03c3",
+            "https://developer.download.nvidia.com/hpc-sdk/23.9/nvhpc_2023_239_Linux_aarch64_cuda_multi.tar.gz",
+        ),
+        "Linux-ppc64le": (
+            "984d61695499db098fd32be8345c1f7d7c637ea3bdb29cef17aad656f16b000f",
+            "https://developer.download.nvidia.com/hpc-sdk/23.9/nvhpc_2023_239_Linux_ppc64le_cuda_multi.tar.gz",
+        ),
+        "Linux-x86_64": (
+            "ecf343ecad2398e21c8d7f24a580b2932348017dfd8ea38c1ef31b37114b2d4b",
+            "https://developer.download.nvidia.com/hpc-sdk/23.9/nvhpc_2023_239_Linux_x86_64_cuda_multi.tar.gz",
+        ),
+    },
+    "23.7": {
+        "Linux-aarch64": (
+            "d3b9b674045e6e17156b298941be4e1e1e7dea6a3c1938f14ad653b180860ff2",
+            "https://developer.download.nvidia.com/hpc-sdk/23.7/nvhpc_2023_237_Linux_aarch64_cuda_multi.tar.gz",
+        ),
+        "Linux-ppc64le": (
+            "67b137cf67e2c8556ef3952d1ee35f4966c9d1968626825924fb8e4b198a532b",
+            "https://developer.download.nvidia.com/hpc-sdk/23.7/nvhpc_2023_237_Linux_ppc64le_cuda_multi.tar.gz",
+        ),
+        "Linux-x86_64": (
+            "fea91d95ff18bca1ce7afde50371caa02001ade8bed6ddfc5ff70862ccbebece",
+            "https://developer.download.nvidia.com/hpc-sdk/23.7/nvhpc_2023_237_Linux_x86_64_cuda_multi.tar.gz",
+        ),
+    },
+    "23.5": {
+        "Linux-aarch64": (
+            "3af202ad36bbf205b2af56aabe63b971c01b5ec0e82a02effb3c4928f63bc657",
+            "https://developer.download.nvidia.com/hpc-sdk/23.5/nvhpc_2023_235_Linux_aarch64_cuda_multi.tar.gz",
+        ),
+        "Linux-ppc64le": (
+            "65b1f1780175096fa58e98e80fc897c0d563cacce43b3e87ba157f40a8e34877",
+            "https://developer.download.nvidia.com/hpc-sdk/23.5/nvhpc_2023_235_Linux_ppc64le_cuda_multi.tar.gz",
+        ),
+        "Linux-x86_64": (
+            "071d7119006cb1d7ac22cb91338c20133a02d394efe14931dfa6f5d7dfa54c81",
+            "https://developer.download.nvidia.com/hpc-sdk/23.5/nvhpc_2023_235_Linux_x86_64_cuda_multi.tar.gz",
+        ),
+    },
+    "23.3": {
+        "Linux-aarch64": (
+            "48c837de0b1d2dc31c313b19da752d27527e706cb4150c7a6185a4218fc24ef3",
+            "https://developer.download.nvidia.com/hpc-sdk/23.3/nvhpc_2023_233_Linux_aarch64_cuda_multi.tar.gz",
+        ),
+        "Linux-ppc64le": (
+            "0f2b5b2fff8ffed13428c55809841b4abd3dfe61e2b1a866bbe959e4bcd50223",
+            "https://developer.download.nvidia.com/hpc-sdk/23.3/nvhpc_2023_233_Linux_ppc64le_cuda_multi.tar.gz",
+        ),
+        "Linux-x86_64": (
+            "b94d2b4ae5a23c1a0af7d5b07c785f5057850fe3a6ee5ba0aacdde1019af5d12",
+            "https://developer.download.nvidia.com/hpc-sdk/23.3/nvhpc_2023_233_Linux_x86_64_cuda_multi.tar.gz",
+        ),
+    },
+    "23.1": {
+        "Linux-aarch64": (
+            "5b430e03752954ea62ac1c745b1735cfdaa43b2e981a9412c1465ecb0412fff6",
+            "https://developer.download.nvidia.com/hpc-sdk/23.1/nvhpc_2023_231_Linux_aarch64_cuda_multi.tar.gz",
+        ),
+        "Linux-ppc64le": (
+            "81759e7c747bf4f552b75e7657301f76ecc0828b94fe860f81108c6e83e6ad2b",
+            "https://developer.download.nvidia.com/hpc-sdk/23.1/nvhpc_2023_231_Linux_ppc64le_cuda_multi.tar.gz",
+        ),
+        "Linux-x86_64": (
+            "55a064415f6d4ce6a01823ee27ebd266f4fb579679871e7c1a7c054bdc18e9f5",
+            "https://developer.download.nvidia.com/hpc-sdk/23.1/nvhpc_2023_231_Linux_x86_64_cuda_multi.tar.gz",
+        ),
+    },
+    "22.11": {
+        "Linux-aarch64": (
+            "e60e798657c33b06754d33dfd5ab3bea2882d4a9b9476102303edf2bbe3b7a95",
+            "https://developer.download.nvidia.com/hpc-sdk/22.11/nvhpc_2022_2211_Linux_aarch64_cuda_multi.tar.gz",
+        ),
+        "Linux-ppc64le": (
+            "ef800203cf6040b3a5df24f19944b272f62caee8362875bcb394e86dc1de2353",
+            "https://developer.download.nvidia.com/hpc-sdk/22.11/nvhpc_2022_2211_Linux_ppc64le_cuda_multi.tar.gz",
+        ),
+        "Linux-x86_64": (
+            "cb91b3a04368457d5cfe3c0e9c0611591fdc8076b01ea977343fe7db7fdcfa3c",
+            "https://developer.download.nvidia.com/hpc-sdk/22.11/nvhpc_2022_2211_Linux_x86_64_cuda_multi.tar.gz",
+        ),
+    },
+    "22.9": {
+        "Linux-aarch64": (
+            "bc4473f04b49bc9a26f08c17a72360650ddf48a3b6eefacdc525d79c8d730f30",
+            "https://developer.download.nvidia.com/hpc-sdk/22.9/nvhpc_2022_229_Linux_aarch64_cuda_multi.tar.gz",
+        ),
+        "Linux-ppc64le": (
+            "9aac31d36bb09f6653544978021f5b78c272112e7748871566f7e930f5e7475b",
+            "https://developer.download.nvidia.com/hpc-sdk/22.9/nvhpc_2022_229_Linux_ppc64le_cuda_multi.tar.gz",
+        ),
+        "Linux-x86_64": (
+            "aebfeb826ace3dabf9699f72390ca0340f8789a8ef6fe4032e3c7b794f073ea3",
+            "https://developer.download.nvidia.com/hpc-sdk/22.9/nvhpc_2022_229_Linux_x86_64_cuda_multi.tar.gz",
+        ),
+    },
+    "22.7": {
+        "Linux-aarch64": (
+            "2aae3fbfd2d0d2d09448a36166c42311368f5600c7c346f159c280b412fe924a",
+            "https://developer.download.nvidia.com/hpc-sdk/22.7/nvhpc_2022_227_Linux_aarch64_cuda_multi.tar.gz",
+        ),
+        "Linux-ppc64le": (
+            "6dd4fd382c22769e4fa9508714119abd7d1df3dc58c69414a14b0b0dbc34564f",
+            "https://developer.download.nvidia.com/hpc-sdk/22.7/nvhpc_2022_227_Linux_ppc64le_cuda_multi.tar.gz",
+        ),
+        "Linux-x86_64": (
+            "3ce1c346f8bc7e50defb41c545c8907fdc012ff60b27eb8985cf3213f19d863a",
+            "https://developer.download.nvidia.com/hpc-sdk/22.7/nvhpc_2022_227_Linux_x86_64_cuda_multi.tar.gz",
+        ),
+    },
+    "22.5": {
+        "Linux-aarch64": (
+            "ceeee84e6227e973ad1beded6008d330e3790f7c4598b948fa530fedfa830a16",
+            "https://developer.download.nvidia.com/hpc-sdk/22.5/nvhpc_2022_225_Linux_aarch64_cuda_multi.tar.gz",
+        ),
+        "Linux-ppc64le": (
+            "54d1e45664352d0f9f85ab476dd39496dd1b290e0e1221d3bf63afb940dbe16d",
+            "https://developer.download.nvidia.com/hpc-sdk/22.5/nvhpc_2022_225_Linux_ppc64le_cuda_multi.tar.gz",
+        ),
+        "Linux-x86_64": (
+            "7674bcf7a77570fafee5b8299959c9e998a9a10bb27904335cf1a58b71766137",
+            "https://developer.download.nvidia.com/hpc-sdk/22.5/nvhpc_2022_225_Linux_x86_64_cuda_multi.tar.gz",
+        ),
+    },
+    "22.3": {
+        "Linux-aarch64": (
+            "e0ea1cbb726556f6879f4b5dfe17238f8e7680c772368577945a85c0e08328f0",
+            "https://developer.download.nvidia.com/hpc-sdk/22.3/nvhpc_2022_223_Linux_aarch64_cuda_multi.tar.gz",
+        ),
+        "Linux-ppc64le": (
+            "5e80db6010adc85fe799dac961ae69e43fdf18d35243666c96a70ecdb80bd280",
+            "https://developer.download.nvidia.com/hpc-sdk/22.3/nvhpc_2022_223_Linux_ppc64le_cuda_multi.tar.gz",
+        ),
+        "Linux-x86_64": (
+            "bc60a6faf2237bf20550718f71079a714563fa85df62c341cb833f70eb2fe7bb",
+            "https://developer.download.nvidia.com/hpc-sdk/22.3/nvhpc_2022_223_Linux_x86_64_cuda_multi.tar.gz",
+        ),
+    },
+    "22.2": {
+        "Linux-aarch64": (
+            "a8241d1139a768d9a0066d1853748160e4098253024e17e997983884d0d33a19",
+            "https://developer.download.nvidia.com/hpc-sdk/22.2/nvhpc_2022_222_Linux_aarch64_cuda_multi.tar.gz",
+        ),
+        "Linux-ppc64le": (
+            "f84f72423452968d5bbe02e297f188682c4759864a736a72b32acb3433db3a26",
+            "https://developer.download.nvidia.com/hpc-sdk/22.2/nvhpc_2022_222_Linux_ppc64le_cuda_multi.tar.gz",
+        ),
+        "Linux-x86_64": (
+            "8dfb4007d6912b2722946358ac69409592c1f03426d81971ffbcb6fc5fea2cb8",
+            "https://developer.download.nvidia.com/hpc-sdk/22.2/nvhpc_2022_222_Linux_x86_64_cuda_multi.tar.gz",
+        ),
+    },
+    "22.1": {
+        "Linux-aarch64": (
+            "05cfa8c520a34eab01272a261b157d421a9ff7129fca7d859b944ce6a16d2255",
+            "https://developer.download.nvidia.com/hpc-sdk/22.1/nvhpc_2022_221_Linux_aarch64_cuda_multi.tar.gz",
+        ),
+        "Linux-ppc64le": (
+            "9fa9b64fba2c9b287b5800693417d8065c695d18cab0526bad41d9aecc8be2b3",
+            "https://developer.download.nvidia.com/hpc-sdk/22.1/nvhpc_2022_221_Linux_ppc64le_cuda_multi.tar.gz",
+        ),
+        "Linux-x86_64": (
+            "7e4366509ed9031ff271e73327dd3121909902a81ac436307801a5373efaff5e",
+            "https://developer.download.nvidia.com/hpc-sdk/22.1/nvhpc_2022_221_Linux_x86_64_cuda_multi.tar.gz",
+        ),
+    },
+    "21.11": {
+        "Linux-aarch64": (
+            "3b11bcd9cca862fabfce1e7bcaa2050ea12130c7e897f4e7859ba4c155d20720",
+            "https://developer.download.nvidia.com/hpc-sdk/21.11/nvhpc_2021_2111_Linux_aarch64_cuda_multi.tar.gz",
+        ),
+        "Linux-ppc64le": (
+            "ac51ed92de4eb5e1bdb064ada5bbace5b89ac732ad6c6473778edfb8d29a6527",
+            "https://developer.download.nvidia.com/hpc-sdk/21.11/nvhpc_2021_2111_Linux_ppc64le_cuda_multi.tar.gz",
+        ),
+        "Linux-x86_64": (
+            "d8d8ccd0e558d22bcddd955f2233219c96f7de56aa8e09e7be833e384d32d6aa",
+            "https://developer.download.nvidia.com/hpc-sdk/21.11/nvhpc_2021_2111_Linux_x86_64_cuda_multi.tar.gz",
+        ),
+    },
+    "21.9": {
+        "Linux-aarch64": (
+            "52c2c66e30043add4afccedf0ba77daa0000bf42e0db844baa630bb635b91a7d",
+            "https://developer.download.nvidia.com/hpc-sdk/21.9/nvhpc_2021_219_Linux_aarch64_cuda_multi.tar.gz",
+        ),
+        "Linux-ppc64le": (
+            "cff0b55fb782be1982bfeec1d9763b674ddbf84ff2c16b364495299266320289",
+            "https://developer.download.nvidia.com/hpc-sdk/21.9/nvhpc_2021_219_Linux_ppc64le_cuda_multi.tar.gz",
+        ),
+        "Linux-x86_64": (
+            "7de6a6880fd7e59afe0dee51f1fae4d3bff1ca0fb8ee234b24e1f2fdff23ffc9",
+            "https://developer.download.nvidia.com/hpc-sdk/21.9/nvhpc_2021_219_Linux_x86_64_cuda_multi.tar.gz",
+        ),
+    },
+    "21.7": {
+        "Linux-aarch64": (
+            "73eb3513845b59645f118b1e313472f54519dc252d5f5c32a05df2a2a8a19878",
+            "https://developer.download.nvidia.com/hpc-sdk/21.7/nvhpc_2021_217_Linux_aarch64_cuda_multi.tar.gz",
+        ),
+        "Linux-ppc64le": (
+            "37ea23b5a9c696fb3fdb82855643afc4e02aea618102ec801206441f10fc9fba",
+            "https://developer.download.nvidia.com/hpc-sdk/21.7/nvhpc_2021_217_Linux_ppc64le_cuda_multi.tar.gz",
+        ),
+        "Linux-x86_64": (
+            "49d6e23492d131474698cf12971722d42e13a54a4eddec382e66e1053b4ac902",
+            "https://developer.download.nvidia.com/hpc-sdk/21.7/nvhpc_2021_217_Linux_x86_64_cuda_multi.tar.gz",
+        ),
+    },
+    "21.5": {
+        "Linux-aarch64": (
+            "1a1748cd7cf538199d92ab3b1208935fa4a62708ba21125aeadb328ddc7380d4",
+            "https://developer.download.nvidia.com/hpc-sdk/21.5/nvhpc_2021_215_Linux_aarch64_cuda_multi.tar.gz",
+        ),
+        "Linux-ppc64le": (
+            "4674931a5ce28724308cb9cebd546eefa3f0646d3d08adbea28ba5ad27f0c163",
+            "https://developer.download.nvidia.com/hpc-sdk/21.5/nvhpc_2021_215_Linux_ppc64le_cuda_multi.tar.gz",
+        ),
+        "Linux-x86_64": (
+            "21989e52c58a6914743631c8200de1fec7e10b3449c6c1833f3032ee74b85f8e",
+            "https://developer.download.nvidia.com/hpc-sdk/21.5/nvhpc_2021_215_Linux_x86_64_cuda_multi.tar.gz",
+        ),
+    },
+    "21.3": {
+        "Linux-aarch64": (
+            "88e0dbf8fcdd06a2ba06aacf65ae1625b8683688f6593ed3bf8ce129ce1b17b7",
+            "https://developer.download.nvidia.com/hpc-sdk/21.3/nvhpc_2021_213_Linux_aarch64_cuda_multi.tar.gz",
+        ),
+        "Linux-ppc64le": (
+            "08cd0cd6c80d633f107b44f88685ada7f014fbf6eac19ef5ae4a7952cabe4037",
+            "https://developer.download.nvidia.com/hpc-sdk/21.3/nvhpc_2021_213_Linux_ppc64le_cuda_multi.tar.gz",
+        ),
+        "Linux-x86_64": (
+            "391d5604a70f61bdd4ca6a3e4692f6f2391948990c8a35c395b6867341890031",
+            "https://developer.download.nvidia.com/hpc-sdk/21.3/nvhpc_2021_213_Linux_x86_64_cuda_multi.tar.gz",
+        ),
+    },
+    "21.2": {
+        "Linux-aarch64": (
+            "fe19c0232f7c9534f8699b7432483c9cc649f1e92e7f0961d1aa7c54d83297ff",
+            "https://developer.download.nvidia.com/hpc-sdk/21.2/nvhpc_2021_212_Linux_aarch64_cuda_multi.tar.gz",
+        ),
+        "Linux-ppc64le": (
+            "6b69b6e4ebec6a91b9f1627384c50adad79ebdd25dfb20a5f64cf01c3a07f11a",
+            "https://developer.download.nvidia.com/hpc-sdk/21.2/nvhpc_2021_212_Linux_ppc64le_cuda_multi.tar.gz",
+        ),
+        "Linux-x86_64": (
+            "a3e3393040185ae844002fbc6c8eb4ffdfb97ce8b2ce29d796fe7e9a521fdc59",
+            "https://developer.download.nvidia.com/hpc-sdk/21.2/nvhpc_2021_212_Linux_x86_64_cuda_multi.tar.gz",
+        ),
+    },
+    "21.1": {
+        "Linux-aarch64": (
+            "b276e7c0ff78cee837a597d9136cd1d8ded27a9d1fdae1e7d674e2a072a9a6aa",
+            "https://developer.download.nvidia.com/hpc-sdk/21.1/nvhpc_2021_211_Linux_aarch64_cuda_multi.tar.gz",
+        ),
+        "Linux-ppc64le": (
+            "bc236c212097bac6b7d04d627d9cc6b75bb6cd473a0b6a1bf010559ce328a2b0",
+            "https://developer.download.nvidia.com/hpc-sdk/21.1/nvhpc_2021_211_Linux_ppc64le_cuda_multi.tar.gz",
+        ),
+        "Linux-x86_64": (
+            "d529daf46404724ac3f005be4239f2c30e53f5220bb9453f367dccc3a74d6b41",
+            "https://developer.download.nvidia.com/hpc-sdk/21.1/nvhpc_2021_211_Linux_x86_64_cuda_multi.tar.gz",
+        ),
+    },
+    "20.11": {
+        "Linux-aarch64": (
+            "2f26ca45b07b694b8669e4f761760d4f7faa8d032b21e430adee1af0a27032c1",
+            "https://developer.download.nvidia.com/hpc-sdk/20.11/nvhpc_2020_2011_Linux_aarch64_cuda_multi.tar.gz",
+        ),
+        "Linux-ppc64le": (
+            "99e5a5437e82f3914e0fe81feb761a5b599a3fe8b31f3c2cac8ae47e8cdc7b0f",
+            "https://developer.download.nvidia.com/hpc-sdk/20.11/nvhpc_2020_2011_Linux_ppc64le_cuda_multi.tar.gz",
+        ),
+        "Linux-x86_64": (
+            "c80fc26e5ba586696f7030f03054c1aaca0752a891c7923faf47eb23b66857ec",
+            "https://developer.download.nvidia.com/hpc-sdk/20.11/nvhpc_2020_2011_Linux_x86_64_cuda_multi.tar.gz",
+        ),
+    },
+    "20.9": {
+        "Linux-aarch64": (
+            "3bfb3d17f5ee99998bcc30d738e818d3b94b828e2d8da7db48bf152a01e22023",
+            "https://developer.download.nvidia.com/hpc-sdk/20.9/nvhpc_2020_209_Linux_aarch64_cuda_11.0.tar.gz",
+        ),
+        "Linux-ppc64le": (
+            "b2966d4047e1dfd981ce63b333ab9c0acbdc2a6a505fa217456ac9fa3b8e7474",
+            "https://developer.download.nvidia.com/hpc-sdk/20.9/nvhpc_2020_209_Linux_ppc64le_cuda_multi.tar.gz",
+        ),
+        "Linux-x86_64": (
+            "fe665ab611b03846a90bd70ca4e08c1e59ab527364b971ed0304e0ae73c778d8",
+            "https://developer.download.nvidia.com/hpc-sdk/20.9/nvhpc_2020_209_Linux_x86_64_cuda_multi.tar.gz",
+        ),
+    },
+    "20.7": {
+        "Linux-aarch64": (
+            "5b83ca1919199ac0aa609309b31c345c5a6453dd3131fddeef9e3ee9059a0e9b",
+            "https://developer.download.nvidia.com/hpc-sdk/20.7/nvhpc_2020_207_Linux_aarch64_cuda_11.0.tar.gz",
+        ),
+        "Linux-ppc64le": (
+            "800ead240bdf61611910b2f6df24ee1d7359377ff3767c923738dd81fcea9312",
+            "https://developer.download.nvidia.com/hpc-sdk/20.7/nvhpc_2020_207_Linux_ppc64le_cuda_multi.tar.gz",
+        ),
+        "Linux-x86_64": (
+            "a5c5c8726d2210f2310a852c6d6e03c9ef8c75e3643e9c94e24909f5e9c2ea7a",
+            "https://developer.download.nvidia.com/hpc-sdk/20.7/nvhpc_2020_207_Linux_x86_64_cuda_multi.tar.gz",
+        ),
+    },
+}
+
+
+class Nvhpc(Package):
+    """The NVIDIA HPC SDK is a comprehensive suite of compilers, libraries
+    and tools essential to maximizing developer productivity and the
+    performance and portability of HPC applications. The NVIDIA HPC
+    SDK C, C++, and Fortran compilers support GPU acceleration of HPC
+    modeling and simulation applications with standard C++ and
+    Fortran, OpenACC directives, and CUDA. GPU-accelerated math
+    libraries maximize performance on common HPC algorithms, and
+    optimized communications libraries enable standards-based
+    multi-GPU and scalable systems programming. Performance profiling
+    and debugging tools simplify porting and optimization of HPC
+    applications."""
+
+    homepage = "https://developer.nvidia.com/hpc-sdk"
+
+    maintainers("samcmill")
+    tags = ["e4s"]
+
+    skip_version_audit = ["platform=darwin"]
+
+    for ver, packages in _versions.items():
+        key = "{0}-{1}".format(platform.system(), platform.machine())
+        pkg = packages.get(key)
+        if pkg:
+            version(ver, sha256=pkg[0], url=pkg[1])
+
+    variant("blas", default=True, description="Enable BLAS")
+    variant(
+        "install_type",
+        default="single",
+        values=("single", "network"),
+        multi=False,
+        description="Network installs are for installations shared "
+        "by different operating systems",
+    )
+    variant("lapack", default=True, description="Enable LAPACK")
+    variant("mpi", default=False, description="Enable MPI")
+    variant(
+        "default_cuda", default="default", description="Default CUDA version, for example 11.8"
+    )
+
+    provides("blas", when="+blas")
+    provides("lapack", when="+lapack")
+    provides("mpi", when="+mpi")
+
+    requires("%gcc", msg="nvhpc must be installed with %gcc")
+
+    def _version_prefix(self):
+        return join_path(self.prefix, "Linux_%s" % self.spec.target.family, self.version)
+
+    def setup_build_environment(self, env):
+        env.set("NVHPC_SILENT", "true")
+        env.set("NVHPC_ACCEPT_EULA", "accept")
+        env.set("NVHPC_INSTALL_DIR", self.prefix)
+        if self.spec.variants["default_cuda"].value != "default":
+            env.set("NVHPC_DEFAULT_CUDA", self.spec.variants["default_cuda"].value)
+
+        if self.spec.variants["install_type"].value == "network":
+            local_dir = join_path(self._version_prefix(), "share_objects")
+            env.set("NVHPC_INSTALL_TYPE", "network")
+            env.set("NVHPC_INSTALL_LOCAL_DIR", local_dir)
+        else:
+            env.set("NVHPC_INSTALL_TYPE", "single")
+
+    def install(self, spec, prefix):
+        compilers_bin = join_path(self._version_prefix(), "compilers", "bin")
+        install = Executable("./install")
+        makelocalrc = Executable(join_path(compilers_bin, "makelocalrc"))
+
+        makelocalrc_args = [
+            "-gcc",
+            self.compiler.cc,
+            "-gpp",
+            self.compiler.cxx,
+            "-g77",
+            self.compiler.f77,
+            "-x",
+            compilers_bin,
+        ]
+        if self.spec.variants["install_type"].value == "network":
+            local_dir = join_path(self._version_prefix(), "share_objects")
+            makelocalrc_args.extend(["-net", local_dir])
+
+        # Run install script
+        install()
+
+        # Update localrc to use Spack gcc
+        makelocalrc(*makelocalrc_args)
+
+    def setup_run_environment(self, env):
+        prefix = Prefix(
+            join_path(self.prefix, "Linux_%s" % self.spec.target.family, self.version, "compilers")
+        )
+
+        env.set("CC", join_path(prefix.bin, "nvc"))
+        env.set("CXX", join_path(prefix.bin, "nvc++"))
+        env.set("F77", join_path(prefix.bin, "nvfortran"))
+        env.set("FC", join_path(prefix.bin, "nvfortran"))
+
+        env.prepend_path("PATH", prefix.bin)
+        env.prepend_path("LIBRARY_PATH", prefix.lib)
+        env.prepend_path("LD_LIBRARY_PATH", prefix.lib)
+        env.prepend_path("MANPATH", prefix.man)
+
+        if "+mpi" in self.spec:
+            mpi_prefix = Prefix(
+                join_path(
+                    self.prefix,
+                    "Linux_%s" % self.spec.target.family,
+                    self.version,
+                    "comm_libs",
+                    "mpi",
+                )
+            )
+            env.prepend_path("PATH", mpi_prefix.bin)
+            env.prepend_path("LD_LIBRARY_PATH", mpi_prefix.lib)
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        prefix = Prefix(
+            join_path(self.prefix, "Linux_%s" % self.spec.target.family, self.version, "compilers")
+        )
+
+        env.prepend_path("LIBRARY_PATH", prefix.lib)
+        env.prepend_path("LD_LIBRARY_PATH", prefix.lib)
+
+        if "+mpi" in self.spec:
+            mpi_prefix = Prefix(
+                join_path(
+                    self.prefix,
+                    "Linux_%s" % self.spec.target.family,
+                    self.version,
+                    "comm_libs",
+                    "mpi",
+                )
+            )
+
+            env.prepend_path("LD_LIBRARY_PATH", mpi_prefix.lib)
+
+    def setup_dependent_package(self, module, dependent_spec):
+        if "+mpi" in self.spec or self.provides("mpi"):
+            mpi_prefix = Prefix(
+                join_path(
+                    self.prefix,
+                    "Linux_%s" % self.spec.target.family,
+                    self.version,
+                    "comm_libs",
+                    "mpi",
+                )
+            )
+
+            self.spec.mpicc = join_path(mpi_prefix.bin, "mpicc")
+            self.spec.mpicxx = join_path(mpi_prefix.bin, "mpicxx")
+            self.spec.mpif77 = join_path(mpi_prefix.bin, "mpif77")
+            self.spec.mpifc = join_path(mpi_prefix.bin, "mpif90")
+
+    @property
+    def libs(self):
+        prefix = Prefix(
+            join_path(self.prefix, "Linux_%s" % self.spec.target.family, self.version, "compilers")
+        )
+        libs = []
+
+        if "+blas" in self.spec:
+            libs.append("libblas")
+
+        if "+lapack" in self.spec:
+            libs.append("liblapack")
+            libs.append("libnvf")
+
+        return find_libraries(libs, root=prefix, recursive=True)
+
+    # Avoid binding stub libraries by absolute path
+    non_bindable_shared_objects = ["stubs"]


### PR DESCRIPTION
Enable Grace-Hopper on Santis through:
* adding cray-mpich 8.1.29 for nvidia toolchain
* adding package.py files for `nvhpc` and `cuda` to the stackinator repo
    *  to provide the latest cuda 12.3 and nvhpc 24.1 for spack v0.20 a v0.2
* adding an up to date `aws-ofi-nccl` package that enables support for NCCL on Slingshot 11