### PR TITLE
Update spack command when using a spack commit between develop and 0.21

### DIFF
--- a/stackinator/templates/Makefile.environments
+++ b/stackinator/templates/Makefile.environments
@@ -31,7 +31,7 @@ all:{% for env in environments %} {{ env }}/generated/build_cache{% endfor %}
 {% for env, config in environments.items() %}
 {{ env }}/generated/view_config: {{ env }}/generated/env
 {% if config.view %}
-{% if develop or (spack_version=="0.21") %}
+{% if develop or (spack_version>="0.21") %}
 	$(SPACK) env activate --with-view default --sh ./{{ env }} > $(STORE)/env/{{ config.view.name }}/activate.sh
 	$(SOFTWARE_STACK_PROJECT)/add-compiler-links.py  ./{{ env }}/compilers.yaml $(STORE)/env/{{ config.view.name }}/activate.sh $(SOFTWARE_STACK_PROJECT)
 {% else %}


### PR DESCRIPTION
When pinning a specific spack commit inbetween develop and 0.21 in a recipe, the spack version is set to 0.22 and it errors out with a missing parameter passed to `--with-view`.