### PR TITLE
exclude packages built from a git branch from build cache

### DIFF
--- a/stackinator/templates/Makefile.environments
+++ b/stackinator/templates/Makefile.environments
@@ -19,8 +19,9 @@ all:{% for env in environments %} {{ env }}/generated/build_cache{% endfor %}
 {{ env }}/generated/build_cache: {{ env }}/generated/view_config
 {% if push_to_cache %}
 	$(SPACK) -e ./{{ env }} buildcache create --rebuild-index --allow-root --only=package alpscache \
-	$$($(SPACK) --color=never -e ./{{ env }} find --format '{name};{/hash}' \
+	$$($(SPACK) --color=never -e ./{{ env }} find --format '{name};{/hash};version={version}' \
 	| grep -v -E '^({% for p in config.exclude_from_cache %}{{ pipejoiner() }}{{ p }}{% endfor %});'\
+	| grep -v -E 'version=git\.'\
 	| cut -d ';' -f2)
 {% endif %}
 	touch $@


### PR DESCRIPTION
Grep for `version=git\.`, for example: `sirius@git.mybranch=develop` is excluded from the build-cache, but not `sirius@=develop`.

Proposal for https://github.com/eth-cscs/stackinator/issues/167