### PR TITLE
compiler paths can be null/None

### DIFF
--- a/stackinator/etc/add-compiler-links.py
+++ b/stackinator/etc/add-compiler-links.py
@@ -67,7 +67,9 @@ compilers = load_compilers_yaml(args.compiler_path)
 
 paths = []
 for c in compilers:
-    local_paths = set([os.path.dirname(v) for k, v in c["paths"].items()])
+    local_paths = set(
+        [os.path.dirname(v) for k, v in c["paths"].items() if v is not None]
+    )
     paths += local_paths
     print(f'adding compiler {c["spec"]} -> {[p for p in local_paths]}')
 


### PR DESCRIPTION
Filter `None` from compiler paths, before calling os.path.dirname.

Compiler paths (for example clang) might be empty.
```
compilers:
- compiler:
    spec: clang@=18.1.1
    paths:
      cc: clang
      cxx: clang++
      f77: null
      fc: null
    flags: {}
```
causing the following error:
```
==> Updating view at /user-environment/env/default
...
  File "/dev/shm/boeschf/ml-base_env/add-compiler-links.py", line 70, in <module>
    local_paths = set([os.path.dirname(v) for k, v in c["paths"].items()])
  File "/dev/shm/boeschf/ml-base_env/add-compiler-links.py", line 70, in <listcomp>
    local_paths = set([os.path.dirname(v) for k, v in c["paths"].items()])
  File "/usr/lib64/python3.6/posixpath.py", line 156, in dirname
    p = os.fspath(p)
TypeError: expected str, bytes or os.PathLike object, not NoneType
...
```