### PR TITLE
link `libmpi_gtl_hsa|cuda.so` to cray mpich libraries

### DIFF
--- a/stackinator/repo/packages/cray-mpich/package.py
+++ b/stackinator/repo/packages/cray-mpich/package.py
@@ -145,6 +145,10 @@ class CrayMpich(Package):
                     continue
                 patchelf("--force-rpath", "--set-rpath", rpath, f, fail_on_error=False)
                 patchelf("--add-needed", "libxpmem.so", f, fail_on_error=False)
+                if "+cuda" in self.spec:
+                    patchelf("--add-needed", "libmpi_gtl_cuda.so", f, fail_on_error=False)
+                if "+rocm" in self.spec:
+                    patchelf("--add-needed", "libmpi_gtl_hsa.so", f, fail_on_error=False)
 
     @run_after("install")
     def fixup_compiler_paths(self):


### PR DESCRIPTION
For `cray-mpich+cuda` (and `cray-mpich+rocm`), run `patchelf --add-needed libmpi_gtl_cuda.so` (.. `hsa`). 

This is only for convenience, when not using the cray compiler wrapper, `libmpi_gtl_cuda.so` needs to be added manually at the moment. After this change, it's enough to link to `libmpi.so`.