### PR TITLE
Fix buildcache docs for read-only cache

### DIFF
--- a/stackinator/schema/cache.json
+++ b/stackinator/schema/cache.json
@@ -3,7 +3,7 @@
     "title": "Schema for Spack Stack cache.yaml",
     "type" : "object",
     "additionalProperties": false,
-    "required": ["key", "root"],
+    "required": ["root"],
     "properties" : {
         "key" : {
             "oneOf": [


### PR DESCRIPTION
The documentation states that
> A build cache can be configured to be read-only by not providing a key in the cache configuration file.

However, not providing a key results in:
```
'key' is a required property

Failed validating 'required' in schema:
    {'$schema': 'http://json-schema.org/draft-07/schema#',
     'additionalProperties': False,
     'properties': {'key': {'default': None,
                            'oneOf': [{'type': 'string'},
                                      {'type': 'null'}]},
                    'root': {'type': 'string'}},
     'required': ['key', 'root'],
     'title': 'Schema for Spack Stack cache.yaml',
     'type': 'object'}
```

This PR removes `key` from the required keywords, since it has a default value `null`.