### PR TITLE
Add support for OpenMPI

### DIFF
--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -284,10 +284,7 @@ class Recipe:
                         spec = f"{mpi_impl}{version_opt} {options or ''}".strip()
 
                         if mpi_gpu:
-                            if mpi_impl not in ("cray-mpich", "openmpi"):
-                                spec = f"{spec} cuda_arch=80"
-                            else:
-                                spec = f"{spec} +{mpi_gpu}"
+                            spec = f"{spec} +{mpi_gpu}"
 
                         environments[name]["specs"].append(spec)
                     else:

--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -15,6 +15,7 @@ class Recipe:
             "3.0a",
             "+xpmem fabrics=ch4ofi ch4_max_vcis=4 process_managers=slurm",
         ),
+        "openmpi": ("5", "+internal-pmix +legacylaunchers +orterunprefix fabrics=cma,ofi,xpmem schedulers=slurm"),
     }
 
     @property
@@ -283,7 +284,7 @@ class Recipe:
                         spec = f"{mpi_impl}{version_opt} {options or ''}".strip()
 
                         if mpi_gpu:
-                            if mpi_impl != "cray-mpich":
+                            if mpi_impl not in ("cray-mpich", "openmpi"):
                                 spec = f"{spec} cuda_arch=80"
                             else:
                                 spec = f"{spec} +{mpi_gpu}"


### PR DESCRIPTION
I'm not quite sure why the non-cray-mpichs have `cuda_arch=80` hardcoded, but that seems like a leftover from the past so I've at least set `openmpi` to behave like `cray-mpich`, i.e. just use `+cuda` and `cuda_arch` from the environment. Apparently OpenMPI has ROCm support (https://docs.open-mpi.org/en/v5.0.x/tuning-apps/networking/rocm.html) but the `openmpi` spack package does not have ROCm support. I have not attempted to add that support. I guess it's fine if attempting to use `openmpi +rocm` will simply fail to concretize?


Requires https://github.com/eth-cscs/alps-cluster-config/pull/5.

Ping @ajocksch and @boeschf.