### PR TITLE
Add a couple of missing spack --color=never

### DIFF
--- a/stackinator/templates/Make.user
+++ b/stackinator/templates/Make.user
@@ -8,6 +8,10 @@ SOFTWARE_STACK_PROJECT := {{ build_path }}
 # What Spack should we use?
 SPACK := spack
 
+# This uses the same spack, but ensures "plain" output.
+# Useful when output has to be manipulated (e.g. build a usable path)
+SPACK_HELPER := $(SPACK) --color=never
+
 # The Spack installation root.
 STORE := {{ store }}
 

--- a/stackinator/templates/Makefile
+++ b/stackinator/templates/Makefile
@@ -66,7 +66,7 @@ store.squashfs: environments generate-config{% if modules %} modules{% endif %}{
 
 	# clean up the __pycache__ paths in the repo
 	$(SANDBOX) find $(STORE)/repo -type d -name __pycache__ -exec rm -r {} +
-	$(SANDBOX) env -u SOURCE_DATE_EPOCH "$$($(SANDBOX) $(SPACK) --color=never -e ./compilers/bootstrap find --format='{prefix}' squashfs | head -n1)/bin/mksquashfs" $(STORE) $@ -all-root -all-time $$(date +%s) -no-recovery -noappend -Xcompression-level 3
+	$(SANDBOX) env -u SOURCE_DATE_EPOCH "$$($(SANDBOX) $(SPACK_HELPER) -e ./compilers/bootstrap find --format='{prefix}' squashfs | head -n1)/bin/mksquashfs" $(STORE) $@ -all-root -all-time $$(date +%s) -no-recovery -noappend -Xcompression-level 3
 
 # Force push all built packages to the build cache
 cache-force: mirror-setup
@@ -78,7 +78,7 @@ cache-force: mirror-setup
 	$(warning ================================================================================)
 	$(SANDBOX) $(MAKE) -C generate-config
 	$(SANDBOX) $(SPACK) -C $(STORE)/config buildcache create --rebuild-index --allow-root --only=package alpscache \
-	$$($(SANDBOX) $(SPACK) --color=never -C $(STORE)/config find --format '{/hash}')
+	$$($(SANDBOX) $(SPACK_HELPER) -C $(STORE)/config find --format '{/hash}')
 {% else %}
 	$(warning "pushing to the build cache is not enabled. See the documentation on how to add a key: https://eth-cscs.github.io/stackinator/build-caches/")
 {% endif %}

--- a/stackinator/templates/Makefile
+++ b/stackinator/templates/Makefile
@@ -66,7 +66,7 @@ store.squashfs: environments generate-config{% if modules %} modules{% endif %}{
 
 	# clean up the __pycache__ paths in the repo
 	$(SANDBOX) find $(STORE)/repo -type d -name __pycache__ -exec rm -r {} +
-	$(SANDBOX) env -u SOURCE_DATE_EPOCH "$$($(SANDBOX) $(SPACK) -e ./compilers/bootstrap find --format='{prefix}' squashfs | head -n1)/bin/mksquashfs" $(STORE) $@ -all-root -all-time $$(date +%s) -no-recovery -noappend -Xcompression-level 3
+	$(SANDBOX) env -u SOURCE_DATE_EPOCH "$$($(SANDBOX) $(SPACK) --color=never -e ./compilers/bootstrap find --format='{prefix}' squashfs | head -n1)/bin/mksquashfs" $(STORE) $@ -all-root -all-time $$(date +%s) -no-recovery -noappend -Xcompression-level 3
 
 # Force push all built packages to the build cache
 cache-force: mirror-setup

--- a/stackinator/templates/Makefile.compilers
+++ b/stackinator/templates/Makefile.compilers
@@ -20,7 +20,7 @@ all:{% for compiler in compilers %} {{ compiler }}/generated/build_cache{% endfo
 {{ compiler }}/generated/build_cache: {{ compiler }}/generated/env
 {% if push_to_cache %}
 	$(SPACK) -e ./{{ compiler }} buildcache create --rebuild-index --allow-root --only=package alpscache \
-	$$($(SPACK) --color=never -e ./{{ compiler }} find --format '{name};{/hash}' \
+	$$($(SPACK_HELPER) -e ./{{ compiler }} find --format '{name};{/hash}' \
 	| grep -v -E '^({% for p in config.exclude_from_cache %}{{ pipejoiner() }}{{ p }}{% endfor %});'\
 	| cut -d ';' -f2)
 {% endif %}
@@ -47,11 +47,11 @@ all:{% for compiler in compilers %} {{ compiler }}/generated/build_cache{% endfo
 {% endfor %}
 # Configure dependencies between compilers
 gcc/compilers.yaml: bootstrap/generated/env
-	$(SPACK) compiler find --scope=user $(call compiler_bin_dirs, $$($(SPACK) --color=never -e ./bootstrap find --format '{prefix}' {{ compilers.gcc.requires }}))
+	$(SPACK) compiler find --scope=user $(call compiler_bin_dirs, $$($(SPACK_HELPER) -e ./bootstrap find --format '{prefix}' {{ compilers.gcc.requires }}))
 
 {% if compilers.llvm %}
 llvm/compilers.yaml: gcc/generated/env
-	$(SPACK) compiler find --scope=user $(call compiler_bin_dirs, $$($(SPACK) --color=never -e ./gcc find --format '{prefix}' {{ compilers.llvm.requires }}))
+	$(SPACK) compiler find --scope=user $(call compiler_bin_dirs, $$($(SPACK_HELPER) -e ./gcc find --format '{prefix}' {{ compilers.llvm.requires }}))
 {% endif %}
 
 

--- a/stackinator/templates/Makefile.environments
+++ b/stackinator/templates/Makefile.environments
@@ -19,7 +19,7 @@ all:{% for env in environments %} {{ env }}/generated/build_cache{% endfor %}
 {{ env }}/generated/build_cache: {{ env }}/generated/view_config
 {% if push_to_cache %}
 	$(SPACK) -e ./{{ env }} buildcache create --rebuild-index --allow-root --only=package alpscache \
-	$$($(SPACK) --color=never -e ./{{ env }} find --format '{name};{/hash};version={version}' \
+	$$($(SPACK_HELPER) -e ./{{ env }} find --format '{name};{/hash};version={version}' \
 	| grep -v -E '^({% for p in config.exclude_from_cache %}{{ pipejoiner() }}{{ p }}{% endfor %});'\
 	| grep -v -E 'version=git\.'\
 	| cut -d ';' -f2)
@@ -50,7 +50,7 @@ all:{% for env in environments %} {{ env }}/generated/build_cache{% endfor %}
 
 # Create the compilers.yaml configuration for each environment
 {% for env, config in environments.items() %}
-{{ env }}_PREFIX = {% for C in config.compiler %} $$($(SPACK) --color=never -e ../compilers/{{ C.toolchain }} find --format '{prefix}' {{ C.spec }}){% endfor %}
+{{ env }}_PREFIX = {% for C in config.compiler %} $$($(SPACK_HELPER) -e ../compilers/{{ C.toolchain }} find --format '{prefix}' {{ C.spec }}){% endfor %}
 
 {{ env }}/compilers.yaml:
 	$(SPACK) compiler find --scope=user $(call compiler_bin_dirs, $({{ env }}_PREFIX))

--- a/stackinator/templates/Makefile.generate-config
+++ b/stackinator/templates/Makefile.generate-config
@@ -4,10 +4,10 @@ CONFIG_DIR = $(STORE)/config
 MODULE_DIR = $(SOFTWARE_STACK_PROJECT)/modules
 
 # These will be the prefixes of the GCCs, LLVMs and NVHPCs in the respective environments.
-ALL_COMPILER_PREFIXES ={% for compiler in all_compilers %} $$($(SPACK) -e ../compilers/{{ compiler }} find --format='{prefix}' gcc llvm nvhpc){% endfor %}
+ALL_COMPILER_PREFIXES ={% for compiler in all_compilers %} $$($(SPACK) --color=never -e ../compilers/{{ compiler }} find --format='{prefix}' gcc llvm nvhpc){% endfor %}
 
 
-COMPILER_PREFIXES ={% for compiler in release_compilers %} $$($(SPACK) -e ../compilers/{{ compiler }} find --format='{prefix}' gcc llvm nvhpc){% endfor %}
+COMPILER_PREFIXES ={% for compiler in release_compilers %} $$($(SPACK) --color=never -e ../compilers/{{ compiler }} find --format='{prefix}' gcc llvm nvhpc){% endfor %}
 
 
 all: $(CONFIG_DIR)/upstreams.yaml $(CONFIG_DIR)/compilers.yaml $(CONFIG_DIR)/packages.yaml $(CONFIG_DIR)/repos.yaml $(MODULE_DIR)/upstreams.yaml $(MODULE_DIR)/compilers.yaml

--- a/stackinator/templates/Makefile.generate-config
+++ b/stackinator/templates/Makefile.generate-config
@@ -4,10 +4,10 @@ CONFIG_DIR = $(STORE)/config
 MODULE_DIR = $(SOFTWARE_STACK_PROJECT)/modules
 
 # These will be the prefixes of the GCCs, LLVMs and NVHPCs in the respective environments.
-ALL_COMPILER_PREFIXES ={% for compiler in all_compilers %} $$($(SPACK) --color=never -e ../compilers/{{ compiler }} find --format='{prefix}' gcc llvm nvhpc){% endfor %}
+ALL_COMPILER_PREFIXES ={% for compiler in all_compilers %} $$($(SPACK_HELPER) -e ../compilers/{{ compiler }} find --format='{prefix}' gcc llvm nvhpc){% endfor %}
 
 
-COMPILER_PREFIXES ={% for compiler in release_compilers %} $$($(SPACK) --color=never -e ../compilers/{{ compiler }} find --format='{prefix}' gcc llvm nvhpc){% endfor %}
+COMPILER_PREFIXES ={% for compiler in release_compilers %} $$($(SPACK_HELPER) -e ../compilers/{{ compiler }} find --format='{prefix}' gcc llvm nvhpc){% endfor %}
 
 
 all: $(CONFIG_DIR)/upstreams.yaml $(CONFIG_DIR)/compilers.yaml $(CONFIG_DIR)/packages.yaml $(CONFIG_DIR)/repos.yaml $(MODULE_DIR)/upstreams.yaml $(MODULE_DIR)/compilers.yaml


### PR DESCRIPTION
After https://github.com/spack/spack/pull/42334 stackinator started raising some errors due to colorised output.

Just for reference, the error look like this

```bash
env: ‘\033[1m/user-environment/linux-sles15-zen/gcc-7.5.0/squashfs-4.6.1-pl5475bjii2xaf3cafaflr2yidf5754h\033[0m/bin/mksquashfs’: No such file or directory
```

In other places `spack --color=never` is already used, so I just applied the same solution also in the other parts that were triggering the error. 

This applies for sure to `develop` branch, but in principle it should not harm in general.

Actually, I think it might be a good idea to have a different `$(SPACK)` variable that already embeds the `--color=never`, so it can be safely used where we use spack not as build tool but as helper to retrieve information (e.g. get install prefix).