### PR TITLE
buildcache create `--allow-root` is default in current spack versions

### DIFF
--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -455,6 +455,7 @@ class Recipe:
             compilers=self.compilers,
             push_to_cache=push_to_cache,
             develop=self.spack_develop,
+            spack_version=self.spack_version,
         )
 
         # generate compilers/<compiler>/spack.yaml

--- a/stackinator/templates/Makefile
+++ b/stackinator/templates/Makefile
@@ -77,7 +77,7 @@ cache-force: mirror-setup
 	$(warning likely have to start a fresh build (but that's okay, because build caches FTW))
 	$(warning ================================================================================)
 	$(SANDBOX) $(MAKE) -C generate-config
-	$(SANDBOX) $(SPACK) -C $(STORE)/config buildcache create --rebuild-index --allow-root --only=package alpscache \
+	$(SANDBOX) $(SPACK) -C $(STORE)/config buildcache create --rebuild-index {% if not develop and (spack_version<"0.21") %}--allow-root{% endif %} --only=package alpscache \
 	$$($(SANDBOX) $(SPACK_HELPER) -C $(STORE)/config find --format '{/hash}')
 {% else %}
 	$(warning "pushing to the build cache is not enabled. See the documentation on how to add a key: https://eth-cscs.github.io/stackinator/build-caches/")

--- a/stackinator/templates/Makefile.compilers
+++ b/stackinator/templates/Makefile.compilers
@@ -19,7 +19,7 @@ all:{% for compiler in compilers %} {{ compiler }}/generated/build_cache{% endfo
 {% for compiler, config in compilers.items() %}
 {{ compiler }}/generated/build_cache: {{ compiler }}/generated/env
 {% if push_to_cache %}
-	$(SPACK) -e ./{{ compiler }} buildcache create --rebuild-index --allow-root --only=package alpscache \
+	$(SPACK) -e ./{{ compiler }} buildcache create --rebuild-index {% if not develop and (spack_version<"0.21") %}--allow-root{% endif %} --only=package alpscache \
 	$$($(SPACK_HELPER) -e ./{{ compiler }} find --format '{name};{/hash}' \
 	| grep -v -E '^({% for p in config.exclude_from_cache %}{{ pipejoiner() }}{{ p }}{% endfor %});'\
 	| cut -d ';' -f2)

--- a/stackinator/templates/Makefile.environments
+++ b/stackinator/templates/Makefile.environments
@@ -18,7 +18,7 @@ all:{% for env in environments %} {{ env }}/generated/build_cache{% endfor %}
 {% for env, config in environments.items() %}
 {{ env }}/generated/build_cache: {{ env }}/generated/view_config
 {% if push_to_cache %}
-	$(SPACK) -e ./{{ env }} buildcache create --rebuild-index --allow-root --only=package alpscache \
+	$(SPACK) -e ./{{ env }} buildcache create --rebuild-index {% if not develop and (spack_version<"0.21") %}--allow-root{% endif %} --only=package alpscache \
 	$$($(SPACK_HELPER) -e ./{{ env }} find --format '{name};{/hash};version={version}' \
 	| grep -v -E '^({% for p in config.exclude_from_cache %}{{ pipejoiner() }}{{ p }}{% endfor %});'\
 	| grep -v -E 'version=git\.'\


### PR DESCRIPTION
As pointed out by @albestro.
from spack changelog (https://github.com/spack/spack/blob/develop/CHANGELOG.md#L313)
```
buildcache push: make `--allow-root` the default and deprecate the option (#38878)
```

It was announced to remove `--allow-root` in spack v0.22, although it is still there with the warning:
```
    if args.allow_root:
        tty.warn(
            "The flag `--allow-root` is the default in Spack 0.21, will be removed in Spack 0.22"
        )
```