### PR TITLE
Better support for multi-compiler environments.

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -101,7 +101,7 @@ The `compiler` field describes a list compilers to use to build the software sta
 Each compiler toolchain is specified using toolchain and spec
 
 ```yaml title="compile all packages with gcc@11.3"
-  compiler
+  compiler:
   - toolchain: gcc
     spec: gcc@11.3
 ```
@@ -110,20 +110,37 @@ Sometimes two compiler toolchains are required, for example when using the `nvhp
 The example below uses the `nvhpc` compilers with gcc@11.3.
 
 ```yaml title="compile all packages with gcc@11.3"
-  compiler
-  - toolchain: llvm
-    spec: nvhpc@22.7
+  compiler:
   - toolchain: gcc
     spec: gcc@11.3
+  - toolchain: llvm
+    spec: nvhpc@22.7
 ```
 
 !!! note
     If more than one version of gcc has been installed, use the same version that was used to install `nvhpc`.
 
 !!! warning
-    As a rule, use a single compiler wherever possible - keep it simple!
+    Stackinator does not test or support using two versions of gcc in the same toolchain.
 
-    We don't test or support using two versions of gcc in the same toolchain.
+The order of the compilers is significant. The first compiler is the default, and the other compilers will only be used to build packages when explicitly added to a spec.
+For example, in the recipe below, only `netcdf-fortran` will be built with the `nvhpc` toolchain, while the root specs `cmake` and `netcdf-c` and all dependencies will be built using the `gcc` toolchain.
+
+
+```yaml title="compile all packages with gcc@11.3"
+  compiler:
+  - toolchain: gcc
+    spec: gcc
+  - toolchain: llvm
+    spec: nvhpc
+  specs
+  - cmake
+  - netcdf-c
+  - netcdf-fortran%nvhpc
+```
+
+!!! note
+    This approach is typically used to build Fortran applications and packages with one toolchain (e.g. `nvhpc`), and all of the C/C++ dependencies with a different toolchain (e.g. `gcc`).
 
 ### MPI
 

--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -293,6 +293,20 @@ class Recipe:
                         # TODO: Create a custom exception type
                         raise Exception(f"Unsupported mpi: {mpi_impl}")
 
+        # set constraints that ensure the the main compiler is always used to build packages
+        # that do not explicitly request a compiler.
+        for name, config in environments.items():
+            compilers = config["compiler"]
+            if len(compilers)==1:
+                config["toolchain_constraints"] = []
+                continue
+            requires = [f"%{compilers[0]['spec']}"]
+            for spec in config["specs"]:
+                if '%' not in spec:
+                    requires.append(spec)
+
+            config["toolchain_constraints"] = requires
+
         # An awkward hack to work around spack not supporting creating activation
         # scripts for each file system view in an environment: it only generates them
         # for the "default" view.

--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -302,7 +302,7 @@ class Recipe:
                 continue
             requires = [f"%{compilers[0]['spec']}"]
             for spec in config["specs"]:
-                if '%' not in spec:
+                if '%' in spec:
                     requires.append(spec)
 
             config["toolchain_constraints"] = requires

--- a/stackinator/templates/environments.spack.yaml
+++ b/stackinator/templates/environments.spack.yaml
@@ -1,4 +1,3 @@
-{% set separator = joiner(', ') %}
 spack:
   include:
 {% if config.packages %}
@@ -13,23 +12,22 @@ spack:
     reuse: false
   specs:
 {% for spec in config.specs %}
-  - {{ spec }}
+  - '{{ spec }}'
 {% endfor %}
   packages:
     all:
-      compiler: [{% for c in config.compiler %}{{ separator() }}{{ c.spec }}{% endfor %}]
+{% set separator = joiner(', ') %}
+      compiler: [{% for c in config.compiler %}{{ separator() }}'{{ c.spec }}'{% endfor %}]
+      require:
+{% set separator = joiner(', ') %}
+      - one_of: [{% for c in config.toolchain_constraints %}{{ separator() }}'{{ c }}'{% endfor %}]
     {% if config.variants %}
-      variants:
-      {% for variant in config.variants %}
-      - {{ variant }}
-      {% endfor %}
-      {% for constraint in config.toolchain_constraints %}
-      - {{ constraint }}
-      {% endfor %}
+{% set separator = joiner(', ') %}
+      variants: [{% for v in config.variants %}{{ separator() }}'{{ v }}'{% endfor %}]
     {% endif %}
     {% if config.mpi.spec %}
     mpi:
-      require: {{ config.mpi.spec }}
+      require: '{{ config.mpi.spec }}'
     {% endif %}
 {% if config.view %}
   view:

--- a/stackinator/templates/environments.spack.yaml
+++ b/stackinator/templates/environments.spack.yaml
@@ -23,6 +23,9 @@ spack:
       {% for variant in config.variants %}
       - {{ variant }}
       {% endfor %}
+      {% for constraint in config.toolchain_constraints %}
+      - {{ constraint }}
+      {% endfor %}
     {% endif %}
     {% if config.mpi.spec %}
     mpi:


### PR DESCRIPTION
Recipe authors are not able to set a "default" compiler when using more than one compiler toolchain to build packages in an environment. As a result, the spec list for such environments can be messy because the author has to explicitly set the compiler for many packages to override the compiler chosen by the concretizer. 

For example, the following sample that explicitly sets `%gcc` from the MCH recipe:

```yaml
  - netcdf-fortran@4.5.4%nvhpc
  - hdf5@1.12.2%nvhpc +szip +hl +fortran +mpi
  - openblas@0.3.21%nvhpc
  - libfyaml@0.7.12%nvhpc
  # Explicitly concretise the packages below with gcc as they shouldn't be
  # built with nvhpc.
  - ca-certificates-mozilla%gcc
  - jasper%gcc
  - libaec%gcc
  - libiconv%gcc
```

This PR makes the first compiler in the toolchain the default, and only overrides that choice for specs that explicitly specify the second compiler. For example, the following `compiler` settings would build with the gcc toolchain by default:

```yaml
  compiler:
    - toolchain: gcc
      spec: gcc
    - toolchain: llvm
      spec: nvhpc
```