### PR TITLE
print http_proxy in env command

### DIFF
--- a/stackinator/main.py
+++ b/stackinator/main.py
@@ -77,7 +77,8 @@ def main():
         root_logger.info("\nConfiguration finished, run the following to build the " "environment:\n")
         root_logger.info(f"cd {builder.path}")
         root_logger.info(
-            'env --ignore-environment http_proxy="$http_proxy" https_proxy="$https_proxy" no_proxy="$no_proxy" PATH=/usr/bin:/bin:`pwd`'
+            'env --ignore-environment http_proxy="$http_proxy" https_proxy="$https_proxy" no_proxy="$no_proxy"'
+            "PATH=/usr/bin:/bin:`pwd`"
             "/spack/bin HOME=$HOME make store.squashfs -j32"
         )
         return 0

--- a/stackinator/main.py
+++ b/stackinator/main.py
@@ -77,7 +77,8 @@ def main():
         root_logger.info("\nConfiguration finished, run the following to build the " "environment:\n")
         root_logger.info(f"cd {builder.path}")
         root_logger.info(
-            "env --ignore-environment PATH=/usr/bin:/bin:`pwd`" "/spack/bin HOME=$HOME make store.squashfs -j32"
+            'env --ignore-environment http_proxy="$http_proxy" https_proxy="$https_proxy" no_proxy="$no_proxy" PATH=/usr/bin:/bin:`pwd`'
+            "/spack/bin HOME=$HOME make store.squashfs -j32"
         )
         return 0
     except Exception as e:


### PR DESCRIPTION
`http_proxy` seems to be default and mandatory on todi/eiger. Print  http_proxy  in the `env --ignore-environment` command. 

It shouldnt' affect balfrin etc, setting `https_proxy=""` seems to have no effect.