### PR TITLE
do not specify one_of if toolchain_constraints is empty

### DIFF
--- a/stackinator/templates/environments.spack.yaml
+++ b/stackinator/templates/environments.spack.yaml
@@ -18,9 +18,11 @@ spack:
     all:
 {% set separator = joiner(', ') %}
       compiler: [{% for c in config.compiler %}{{ separator() }}'{{ c.spec }}'{% endfor %}]
+{% if config.toolchain_constraints %}
       require:
 {% set separator = joiner(', ') %}
       - one_of: [{% for c in config.toolchain_constraints %}{{ separator() }}'{{ c }}'{% endfor %}]
+{% endif %}
     {% if config.variants %}
 {% set separator = joiner(', ') %}
       variants: [{% for v in config.variants %}{{ separator() }}'{{ v }}'{% endfor %}]


### PR DESCRIPTION
Environments with only a single compiler defined generated spack.yaml contained:

```
packages:
  require:
  - one_of : []
```
Which caused concretization errors.

This PR only adds `pakcages.require.one_of` if `toolchain_constraints` is not empty.