### PR TITLE
Avoid /dev/null for spack@develop

### DIFF
--- a/stackinator/builder.py
+++ b/stackinator/builder.py
@@ -252,6 +252,7 @@ class Builder:
         with (self.path / "Make.user").open("w") as f:
             f.write(
                 make_user_template.render(
+                    develop=self.spack_develop,
                     build_path=self.path,
                     store=recipe.mount,
                     no_bwrap=recipe.no_bwrap,

--- a/stackinator/templates/Make.user
+++ b/stackinator/templates/Make.user
@@ -37,7 +37,12 @@ export SPACK_COLOR := always
 # config files in ~/.spack. Note that our recommended bwrap setup already puts
 # a tmpfs in the home folder, but when bwrap isn't used, this also helps a bit
 # with reproducibility.
+{% if develop %}
+# spack develop after 0.22.1 chokes on /dev/null
+export SPACK_USER_CONFIG_PATH := ~
+{% else %}
 export SPACK_USER_CONFIG_PATH := /dev/null
+{% endif %}
 
 # Set up the system config scope that has the system packages we don't want
 # build, for example slurm, pmix, etc. Also should have the system compiler.


### PR DESCRIPTION
Current `spack@develop` wants to read config from `SPACK_USER_CONFIG_PATH ` despite it has been set to `/dev/null`. Use $HOME hidden by tmpfs instead.

```
[daint][simonpi@nid006880 build-bwrap]$ env --ignore-environment http_proxy="$http_proxy" https_proxy="$https_proxy" no_proxy="$no_proxy" PATH=/usr/bin:/bin:`pwd`/spack/bin HOME=$HOME make store.squashfs -j32
/dev/shm/simonpi/build-bwrap/bwrap-mutable-root.sh --tmpfs ~ --bind /dev/shm/simonpi/build-bwrap/tmp /tmp --bind /dev/shm/simonpi/build-bwrap/store /user-environment spack --version > spack-version
spack arch... ==> Error: Path is not a file or is not readable: /dev/null/config.yaml: [Errno 20] Not a directory: '/dev/null/config.yaml'

spack version... 0.23.0.dev0 (0fee2c234ef1eda5483a2da5c6bd679c48d7ab26)
checking if spack concretizer works...  failed, see /dev/shm/simonpi/build-bwrap/spack-bootstrap-output
make: *** [Makefile:15: spack-setup] Error 1
```