### PR TITLE
Fix printing of spack commit into generated Makefile

### DIFF
--- a/stackinator/builder.py
+++ b/stackinator/builder.py
@@ -219,7 +219,7 @@ class Builder:
         git_commit_result = subprocess.run(
             ["git", "-C", spack_path, "rev-parse", "HEAD"], shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
-        spack_meta = {"commit": git_commit_result.stdout.strip(), "url": spack["repo"]}
+        spack_meta = {"commit": git_commit_result.stdout.strip().decode("utf-8"), "url": spack["repo"]}
 
         # load the jinja templating environment
         template_path = self.root / "templates"

--- a/stackinator/builder.py
+++ b/stackinator/builder.py
@@ -215,19 +215,11 @@ class Builder:
                 self._logger.debug(f'unable to change to the requested commit {spack["commit"]}')
                 capture.check_returncode()
 
-        # the default branch is develop: find the exact commit
-        if not spack["commit"] or spack["commit"] == "develop":
-            git_commit_result = subprocess.run(
-                ["git", "-C", spack_path, "rev-parse", "HEAD"],
-                shell=False,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-            )
-            spack["commit"] = git_commit_result.stdout.strip()
-
         # get the spack commit
-        spack_meta = {"commit": spack["commit"], "url": spack["repo"]}
-        print(f"==== {spack_meta}")
+        git_commit_result = subprocess.run(
+            ["git", "-C", spack_path, "rev-parse", "HEAD"], shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        spack_meta = {"commit": git_commit_result.stdout.strip(), "url": spack["repo"]}
 
         # load the jinja templating environment
         template_path = self.root / "templates"


### PR DESCRIPTION
Reverts #199, and instead explicitly decodes the result of `git rev-parse` to ensure the commit is printed in the Makefile without a `b'...'` prefix.