### PR TITLE
more consistent build cache exclusion

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,6 +2,7 @@ name: Stackinator CI
 
 on: [push, pull_request]
 
+jobs:
   unittestpy36:
     runs-on: ubuntu-20.04
     strategy:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,25 +2,6 @@ name: Stackinator CI
 
 on: [push, pull_request]
 
-jobs:
-  unittest:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Bootstrap
-      run: |
-        ./bootstrap.sh
-    - name: Generic Unittests
-      run: |
-        ./test_stackinator.py
-
   unittestpy36:
     runs-on: ubuntu-20.04
     strategy:

--- a/stackinator/builder.py
+++ b/stackinator/builder.py
@@ -258,7 +258,7 @@ class Builder:
                     pre_install_hook=recipe.pre_install_hook,
                     spack_version=spack_version,
                     spack_meta=spack_meta,
-                    exclude_from_cache=["nvhpc", "cuda"],
+                    exclude_from_cache=["nvhpc", "cuda", "perl"],
                     verbose=False,
                 )
             )

--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -278,7 +278,7 @@ class Recipe:
 
         # enumerate large binary packages that should not be pushed to binary caches
         for _, config in environments.items():
-            config["exclude_from_cache"] = ["cuda"]
+            config["exclude_from_cache"] = ["cuda", "nvhpc", "perl"]
 
         # check the environment descriptions and ammend where features are missing
         for name, config in environments.items():
@@ -433,7 +433,7 @@ class Recipe:
             f"{bootstrap_spec} languages=c,c++",
             "squashfs default_compression=zstd",
         ]
-        bootstrap["exclude_from_cache"] = []
+        bootstrap["exclude_from_cache"] = ["cuda", "nvhpc", "perl"]
         compilers["bootstrap"] = bootstrap
 
         gcc = {}
@@ -460,7 +460,7 @@ class Recipe:
         }
         gcc["specs"] = raw["gcc"]["specs"]
         gcc["requires"] = bootstrap_spec
-        gcc["exclude_from_cache"] = []
+        gcc["exclude_from_cache"] = ["cuda", "nvhpc", "perl"]
         compilers["gcc"] = gcc
         if raw["llvm"] is not None:
             llvm = {}
@@ -474,7 +474,7 @@ class Recipe:
                     llvm["specs"].append(f"{spec} +clang targets=x86 ~gold ^ninja@kitware")
 
             llvm["requires"] = raw["llvm"]["requires"]
-            llvm["exclude_from_cache"] = ["nvhpc"]
+            llvm["exclude_from_cache"] = ["cuda", "nvhpc", "perl"]
             compilers["llvm"] = llvm
 
         self.compilers = compilers


### PR DESCRIPTION
Clean up build cache exclusion list.
Add perl to the list, because pulling perl from build cache breaks builds of many PerlPackages

* do not push perl to build cache
* consistent build cache exclusion list