### PR TITLE
Add Openmpi using new libfabric to stackinator options

### DIFF
--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -15,7 +15,7 @@ class Recipe:
             "3.0a",
             "+xpmem fabrics=ch4ofi ch4_max_vcis=4 process_managers=slurm",
         ),
-        "openmpi": ("5", "+internal-pmix +legacylaunchers +orterunprefix fabrics=cma,ofi,xpmem schedulers=slurm"),
+        "openmpi": ("5", "+internal-pmix fabrics=cma,ofi,xpmem schedulers=slurm +cray-xpmem ^libfabric@main ^libcxi@main ^cxi-driver@main ^cassini-headers@main"),
     }
 
     @property

--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -311,7 +311,10 @@ class Recipe:
                         spec = f"{mpi_impl}{version_opt} {options or ''}".strip()
 
                         if mpi_gpu:
-                            spec = f"{spec} +{mpi_gpu}"
+                            if '^' in spec:
+                                spec = spec.replace('^', f'+{mpi_gpu} ^', 1)
+                            else:
+                                spec = f"{spec} +{mpi_gpu}"
 
                         environments[name]["specs"].append(spec)
                     else:


### PR DESCRIPTION
```
  mpi:
    spec: openmpi
    gpu: cuda
```
should now use the latest openmpi@5 and new libfabric