### PR TITLE
Some minor fixes and cleanups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,7 @@ line-length = 120
 [tool.isort]
 profile = "black"
 skip = ["external/"]
+
+[tool.ruff]
+line-length = 120
+extend-exclude = ["external/", "unittests/recipes"]

--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -402,7 +402,7 @@ class Recipe:
         self.environments = environments
 
     # creates the self.compilers field that describes the full specifications
-    # for all of teh compilers from the raw compilers.yaml input
+    # for all of the compilers from the raw compilers.yaml input
     def generate_compiler_specs(self, raw):
         compilers = {}
 

--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -59,11 +59,11 @@ class Recipe:
         if not self.mount.is_dir():
             raise FileNotFoundError(f"the mount point '{self.mount}' must exist")
 
-        # required compiler.yaml file
+        # required compilers.yaml file
         compiler_path = self.path / "compilers.yaml"
         self._logger.debug(f"opening {compiler_path}")
         if not compiler_path.is_file():
-            raise FileNotFoundError(f"The recipe path '{compiler_path}' does " f"not contain compilers.yaml")
+            raise FileNotFoundError(f"The recipe path '{compiler_path}' does not contain compilers.yaml")
 
         with compiler_path.open() as fid:
             raw = yaml.load(fid, Loader=yaml.Loader)
@@ -74,7 +74,7 @@ class Recipe:
         environments_path = self.path / "environments.yaml"
         self._logger.debug(f"opening {environments_path}")
         if not environments_path.is_file():
-            raise FileNotFoundError(f"The recipe path '{environments_path}' does " f" not contain environments.yaml")
+            raise FileNotFoundError(f"The recipe path '{environments_path}' does not contain environments.yaml")
 
         with environments_path.open() as fid:
             raw = yaml.load(fid, Loader=yaml.Loader)
@@ -102,7 +102,7 @@ class Recipe:
         mirrors_path = self.path / "mirrors.yaml"
         if mirrors_path.is_file():
             self._logger.warning(
-                "mirrors.yaml have been removed from recipes," " use the --cache option on stack-config instead."
+                "mirrors.yaml have been removed from recipes, use the --cache option on stack-config instead."
             )
             raise RuntimeError("Unsupported mirrors.yaml file in recipe.")
 
@@ -200,7 +200,7 @@ class Recipe:
     def config(self, config_path):
         self._logger.debug(f"opening {config_path}")
         if not config_path.is_file():
-            raise FileNotFoundError(f"The recipe path '{config_path}' does not contain compilers.yaml")
+            raise FileNotFoundError(f"The recipe path '{config_path}' does not contain config.yaml")
 
         with config_path.open() as fid:
             raw = yaml.load(fid, Loader=yaml.Loader)
@@ -378,7 +378,7 @@ class Recipe:
             environments[name]["view"] = None
             for i in range(numviews):
                 # pick a name for the environment
-                cname = name if i == 0 else name + f"-{i+1}__"
+                cname = name if i == 0 else name + f"-{i + 1}__"
                 if i > 0:
                     environments[cname] = copy.deepcopy(base)
 

--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -419,14 +419,6 @@ class Recipe:
                 "texinfo",
                 "gawk",
             ],
-            "variants": {
-                "gcc": "[build_type=Release ~bootstrap +strip]",
-                "mpc": "[libs=static]",
-                "gmp": "[libs=static]",
-                "mpfr": "[libs=static]",
-                "zstd": "[libs=static]",
-                "zlib": "[~shared]",
-            },
         }
         bootstrap_spec = raw["bootstrap"]["spec"]
         bootstrap["specs"] = [
@@ -449,14 +441,6 @@ class Recipe:
                 "texinfo",
                 "gawk",
             ],
-            "variants": {
-                "gcc": "[build_type=Release +profiled +strip]",
-                "mpc": "[libs=static]",
-                "gmp": "[libs=static]",
-                "mpfr": "[libs=static]",
-                "zstd": "[libs=static]",
-                "zlib": "[~shared]",
-            },
         }
         gcc["specs"] = raw["gcc"]["specs"]
         gcc["requires"] = bootstrap_spec

--- a/stackinator/templates/Makefile.compilers
+++ b/stackinator/templates/Makefile.compilers
@@ -32,16 +32,11 @@ all:{% for compiler in compilers %} {{ compiler }}/generated/build_cache{% endfo
 {% for compiler in compilers %}{{ compiler }}/config.yaml {% endfor %}: | store
 	$(SPACK) config --scope=user add config:install_tree:root:$(STORE)
 
-# Configure the install location.
-{% for compiler in compilers %}{{ compiler }}/config.yaml {% endfor %}: | store
-	$(SPACK) config --scope=user add config:install_tree:root:$(STORE)
-
 # Configure external system dependencies for each compiler toolchain
 {% for compiler, config in compilers.items() %}
 {% if config.packages and config.packages.external %}
 {{ compiler }}/packages.yaml:
 	$(SPACK) external find --scope=user {% for package in config.packages.external %} {{package}}{% endfor %}
-
 
 {% endif %}
 {% endfor %}

--- a/stackinator/templates/compilers.gcc.spack.yaml
+++ b/stackinator/templates/compilers.gcc.spack.yaml
@@ -13,7 +13,7 @@ spack:
     reuse: false
   packages:
     gcc:
-      variants: [build_type=Release +strip]
+      variants: [build_type=Release +profiled +strip]
     mpc:
       variants: [libs=static]
     gmp:

--- a/stackinator/templates/compilers.gcc.spack.yaml
+++ b/stackinator/templates/compilers.gcc.spack.yaml
@@ -13,7 +13,7 @@ spack:
     reuse: false
   packages:
     gcc:
-      variants: [build_type=Release +bootstrap +profiled +strip]
+      variants: [build_type=Release +bootstrap +strip]
     mpc:
       variants: [libs=static]
     gmp:

--- a/stackinator/templates/compilers.gcc.spack.yaml
+++ b/stackinator/templates/compilers.gcc.spack.yaml
@@ -13,7 +13,7 @@ spack:
     reuse: false
   packages:
     gcc:
-      variants: [build_type=Release +profiled +strip]
+      variants: [build_type=Release +bootstrap +profiled +strip]
     mpc:
       variants: [libs=static]
     gmp:


### PR DESCRIPTION
Changelog:
- remove hard-coded variants (not used, templates ones are)
- remove duplicated target from `Makefile.compilers` (70f1ebb8220f62cd6521398e357a95bddd2adeba)
- added `ruff` to `pyproject.toml`
- some formatting and typos fixing

About first point, I currently went for enabling `gcc +profiled` in the template as it was in the unused hard-coded variants, just because it sounds like a good thing. I'm not sure how much difference it will make, but it can make a difference in terms of cache reuse for future uenv builds. Indeed, AFAICT, `spack info gcc` reports

```
Variants:
...
    bootstrap [true]                   false, true
        Enable 3-stage bootstrap
...
    when %gcc+bootstrap
      profiled [false]                 false, true
          Use Profile Guided Optimization
```

which means that before this PR stackinator was configuring the bootstrapped compiler as `gcc+bootstrap~profiled` and now it should (implicitly) become `gcc+bootstrap+profiled`.

Waiting for your comments about this decision, which we can easily revert and keep the bootstrapped compiler as `gcc+bootstrap~profiled`.