### PR TITLE
docs: hint about backporting a package

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -358,6 +358,22 @@ Additional custom packages can be provided as part of the cluster configuration,
 These packages are all optional, and will be installed together in a single Spack package repository that is made available to downstream users of the generated uenv stack.
 See the documentation for [cluster configuration](cluster-config.md) for more detail.
 
+!!! note
+    If you need to backport a spack package from a more recent spack version, you can do it by using an already checked out spack repository like this
+
+    (disclaimer: the package might need adjustments due to spack directives changes)
+
+    ```
+    # ensure to have the folder for custom packages in your recipe
+    mkdir -p stackinator-recipe/repo/packages
+    # switch to the already checked out spack repository
+    cd $SPACK_ROOT
+    # use git to extract package files into your "custom packages" section of the stackinator recipe
+    git archive origin/develop `spack location -p fmt` | tar -x --strip-components=5 -C stackinator-recipe/repo/packages
+    ```
+
+    In the above case, the package `fmt` is backported from `origin/develop` into the `stackinator-recipe`.
+
 !!! alps
     All packages are installed under a single spack package repository called `alps`.
     The CSCS configurations in [github.com/eth-cscs/alps-cluster-config](https://github.com/eth-cscs/alps-cluster-config) provides a site configuration that defines cray-mpich, its dependencies, and the most up to date versions of cuda, nvhpc etc to all clusters on Alps.


### PR DESCRIPTION
Opening this PR for adding an hint about package backporting that might be beneficial for some users.

I think this PR is relevant
- for sure for `release/v5` which supports spack up to 0.23, where packages will not get updates anymore
- but it might useful also more generally also for spack 1.0 and newer (so `main`), since one might want to use a specific commit for spack but have a more recent version of a package that has been updated after that commit.

As always, open for any comment and thanks in advance.