### PR TITLE
Fix schema: `config:spack:packages` is a required entry

### DIFF
--- a/stackinator/schema.py
+++ b/stackinator/schema.py
@@ -45,7 +45,7 @@ validator = extend_with_default(jsonschema.Draft7Validator)
 
 # load recipe yaml schema
 config_schema = json.load(open(prefix / "schema/config.json"))
-config_validator = validator(config_schema)
+config_validator = extend_with_default(jsonschema.Draft201909Validator)(config_schema)
 compilers_schema = json.load(open(prefix / "schema/compilers.json"))
 compilers_validator = validator(compilers_schema)
 environments_schema = json.load(open(prefix / "schema/environments.json"))

--- a/stackinator/schema/config.json
+++ b/stackinator/schema/config.json
@@ -15,6 +15,7 @@
         "spack" : {
             "type" : "object",
             "additionalProperties": false,
+            "required": ["packages"],
             "properties" : {
                 "repo": {
                     "type": "string"

--- a/stackinator/schema/config.json
+++ b/stackinator/schema/config.json
@@ -1,9 +1,9 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "http://json-schema.org/draft-2019-09/schema#",
     "title": "Schema for Spack Stack config.yaml recipe file",
     "type" : "object",
-    "additionalProperties": false,
-    "required": ["name", "spack"],
+    "unevaluatedProperties": false,
+    "required": ["name"],
     "properties" : {
         "name" : {
             "type": "string"
@@ -11,39 +11,6 @@
         "store" : {
             "type" : "string",
             "default" : "/user-environment"
-        },
-        "spack" : {
-            "type" : "object",
-            "additionalProperties": false,
-            "required": ["packages"],
-            "properties" : {
-                "repo": {
-                    "type": "string"
-                },
-                "commit": {
-                    "oneOf": [
-                        {"type" : "string"},
-                        {"type" : "null"}
-                    ],
-                    "default": null
-                },
-                "packages" : {
-                    "type" : "object",
-                    "additionalProperties": false,
-                    "properties" : {
-                        "repo": {
-                            "type": "string"
-                        },
-                        "commit": {
-                            "oneOf": [
-                                {"type" : "string"},
-                                {"type" : "null"}
-                            ],
-                            "default": null
-                        }
-                    }
-                }
-            }
         },
         "mirror" : {
             "type" : "object",
@@ -78,5 +45,75 @@
             "type": "number",
             "default": 1
         }
+    },
+    "allOf": [
+      {
+        "if": {
+          "required": ["version"],
+          "properties": {
+            "version": {"const": 2 }
+          }
+        },
+        "then": {
+          "required": ["spack"],
+          "properties": {
+            "spack": {
+              "$ref": "#/$defs/git-repo",
+              "unevaluatedProperties": false,
+              "required": ["packages"],
+              "properties": {
+                "packages": {
+                  "$ref": "#/$defs/git-repo",
+                  "unevaluatedProperties": false
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "if": {
+          "oneOf": [
+            {
+              "not": {
+                "required": ["version"]
+              }
+            },
+            {
+              "required": ["version"],
+              "properties": {
+                "version": {"const": 1 }
+              }
+            }
+          ]
+        },
+        "then": {
+          "required": ["spack"],
+          "properties": {
+            "spack": {
+              "$ref": "#/$defs/git-repo",
+              "unevaluatedProperties": false
+            }
+          }
+        }
+      }
+    ],
+    "$defs": {
+      "git-repo": {
+        "type" : "object",
+        "required": ["repo"],
+        "properties" : {
+          "repo": {
+            "type": "string"
+          },
+          "commit": {
+            "oneOf": [
+                {"type" : "string"},
+                {"type" : "null"}
+            ],
+            "default": null
+          }
+        }
+      }
     }
 }

--- a/stackinator/schema/config.json
+++ b/stackinator/schema/config.json
@@ -44,7 +44,7 @@
         "version" : {
             "type": "number",
             "default": 1,
-            "minumum": 1,
+            "minimum": 1,
             "maximum": 2
         }
     },

--- a/stackinator/schema/config.json
+++ b/stackinator/schema/config.json
@@ -43,7 +43,9 @@
         },
         "version" : {
             "type": "number",
-            "default": 1
+            "default": 1,
+            "minumum": 1,
+            "maximum": 2
         }
     },
     "allOf": [
@@ -95,6 +97,14 @@
               "unevaluatedProperties": false
             }
           }
+        }
+      },
+      {
+        "if": {
+          "not": { "properties": { "version": { "minimum": 1, "maximum": 2} } }
+        },
+        "then": {
+          "properties": { "spack": {} }
         }
       }
     ],

--- a/unittests/test_schema.py
+++ b/unittests/test_schema.py
@@ -58,6 +58,16 @@ def test_config_yaml(yaml_path):
         assert raw["mirror"] == {"enable": True, "key": "/home/bob/veryprivate.key"}
         assert raw["description"] == "a really useful environment"
 
+    with open(yaml_path / "config.defaults.v2.yaml") as fid:
+        raw = yaml.load(fid, Loader=yaml.Loader)
+        schema.config_validator.validate(raw)
+        assert raw["store"] == "/user-environment"
+        assert raw["spack"]["commit"] is None
+        assert raw["spack"]["packages"]["commit"] is None
+        assert raw["modules"] == True  # noqa: E712
+        assert raw["mirror"] == {"enable": True, "key": None}
+        assert raw["description"] is None
+
 
 def test_recipe_config_yaml(recipe_paths):
     # validate the config.yaml in the test recipes

--- a/unittests/test_schema.py
+++ b/unittests/test_schema.py
@@ -40,7 +40,8 @@ def test_config_yaml(yaml_path):
     # test that the defaults are set as expected
     with open(yaml_path / "config.defaults.yaml") as fid:
         raw = yaml.load(fid, Loader=yaml.Loader)
-        schema.validator(schema.config_schema).validate(raw)
+        schema.config_validator.validate(raw)
+        assert raw["version"] == 1
         assert raw["store"] == "/user-environment"
         assert raw["spack"]["commit"] is None
         assert raw["modules"] == True  # noqa: E712
@@ -49,7 +50,8 @@ def test_config_yaml(yaml_path):
 
     with open(yaml_path / "config.full.yaml") as fid:
         raw = yaml.load(fid, Loader=yaml.Loader)
-        schema.validator(schema.config_schema).validate(raw)
+        schema.config_validator.validate(raw)
+        assert raw["version"] == 1
         assert raw["store"] == "/alternative-point"
         assert raw["spack"]["commit"] == "6408b51"
         assert raw["modules"] == False  # noqa: E712
@@ -62,21 +64,21 @@ def test_recipe_config_yaml(recipe_paths):
     for p in recipe_paths:
         with open(p / "config.yaml") as fid:
             raw = yaml.load(fid, Loader=yaml.Loader)
-            schema.validator(schema.config_schema).validate(raw)
+            schema.config_validator.validate(raw)
 
 
 def test_compilers_yaml(yaml_path):
     # test that the defaults are set as expected
     with open(yaml_path / "compilers.defaults.yaml") as fid:
         raw = yaml.load(fid, Loader=yaml.Loader)
-        schema.validator(schema.compilers_schema).validate(raw)
+        schema.compilers_validator.validate(raw)
         assert raw["bootstrap"] == {"spec": "gcc@11"}
         assert raw["gcc"] == {"specs": ["gcc@10.2"]}
         assert raw["llvm"] is None
 
     with open(yaml_path / "compilers.full.yaml") as fid:
         raw = yaml.load(fid, Loader=yaml.Loader)
-        schema.validator(schema.compilers_schema).validate(raw)
+        schema.compilers_validator.validate(raw)
         assert raw["bootstrap"]["spec"] == "gcc@11"
         assert raw["gcc"] == {"specs": ["gcc@11", "gcc@10.2", "gcc@9.3.0"]}
         assert raw["llvm"] == {
@@ -90,13 +92,13 @@ def test_recipe_compilers_yaml(recipe_paths):
     for p in recipe_paths:
         with open(p / "compilers.yaml") as fid:
             raw = yaml.load(fid, Loader=yaml.Loader)
-            schema.validator(schema.compilers_schema).validate(raw)
+            schema.compilers_validator.validate(raw)
 
 
 def test_environments_yaml(yaml_path):
     with open(yaml_path / "environments.full.yaml") as fid:
         raw = yaml.load(fid, Loader=yaml.Loader)
-        schema.validator(schema.environments_schema).validate(raw)
+        schema.environments_validator.validate(raw)
 
         # the defaults-env does not set fields
         # test that they have been set to the defaults correctly
@@ -145,7 +147,7 @@ def test_environments_yaml(yaml_path):
             jsonschema.exceptions.ValidationError,
             match=r"Additional properties are not allowed \('providers' was unexpected",
         ):
-            schema.validator(schema.environments_schema).validate(raw)
+            schema.environments_validator.validate(raw)
 
 
 def test_recipe_environments_yaml(recipe_paths):
@@ -153,4 +155,4 @@ def test_recipe_environments_yaml(recipe_paths):
     for p in recipe_paths:
         with open(p / "environments.yaml") as fid:
             raw = yaml.load(fid, Loader=yaml.Loader)
-            schema.validator(schema.environments_schema).validate(raw)
+            schema.environments_validator.validate(raw)

--- a/unittests/yaml/config.defaults.v2.yaml
+++ b/unittests/yaml/config.defaults.v2.yaml
@@ -1,0 +1,13 @@
+version: 2
+name: cuda-env
+# store: /user-environment
+spack:
+    repo: https://github.com/spack/spack.git
+    # commit: None
+    packages:
+      repo: https://github.com/spack/spack-packages.git
+      # commit: None
+# mirror:
+    # key: None
+    # enable: True
+# modules: True


### PR DESCRIPTION
`config:spack:packages` is a required entry but the schema has not been updated to reflect that.

The "minimal" required entry for `config.yaml` is

```yaml
version: 2
name: blabla
spack:
  repo: https://github.com/spack/spack.git
  packages:
    repo: https://github.com/spack/spack-packages.git
```

For this PR the easiest way was also the one that made most sense to me.
But in the future, we might opt for having official repos as defaults.