### PR TITLE
Remove compiler preference from generated environment config files

### DIFF
--- a/stackinator/templates/environments.spack.yaml
+++ b/stackinator/templates/environments.spack.yaml
@@ -11,10 +11,10 @@ spack:
 {% for spec in config.specs %}
   - '{{ spec }}'
 {% endfor %}
+{% if config.toolchain_constraints or config.variants or config.mpi.spec %}
   packages:
+{% if config.toolchain_constraints or config.variants %}
     all:
-{% set separator = joiner(', ') %}
-      compiler: [{% for c in config.compiler %}{{ separator() }}'{{ c.spec }}'{% endfor %}]
 {% if config.toolchain_constraints %}
       require:
 {% set separator = joiner(', ') %}
@@ -24,10 +24,12 @@ spack:
 {% set separator = joiner(', ') %}
       variants: [{% for v in config.variants %}{{ separator() }}'{{ v }}'{% endfor %}]
     {% endif %}
+{% endif %}
     {% if config.mpi.spec %}
     mpi:
       require: '{{ config.mpi.spec }}'
     {% endif %}
+{% endif %}
 {% if config.view %}
   view:
     default:


### PR DESCRIPTION
I'm still looking at if/how to set toolchain preferences more thoroughly. In the meantime, removing the `compiler` section from the generated `spack.yaml` config files, does no harm and gets rid of the warning about it being ignored.