### PR TITLE
schema: validate schemas against meta-schemas

### DIFF
--- a/test_schemas.py
+++ b/test_schemas.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#   "jsonschema",
+# ]
+# ///
+
+import pathlib
+import json
+
+from jsonschema.validators import validator_for
+
+prefix = pathlib.Path(__file__).parent.resolve() / "stackinator/schema"
+
+if __name__ == "__main__":
+    for schema_filepath in prefix.iterdir():
+        print(f"checking {schema_filepath}")
+        schema = json.load(open(schema_filepath))
+        validator = validator_for(schema)
+        validator.check_schema(schema)


### PR DESCRIPTION
The idea behind this is to add a CI check that validates schemas against meta schemas, aiming at early catching small errors like https://github.com/eth-cscs/stackinator/pull/252.

