### PR TITLE
schema: refactor validators and add pre-check for version

### DIFF
--- a/stackinator/cache.py
+++ b/stackinator/cache.py
@@ -12,7 +12,7 @@ def configuration_from_file(file, mount):
         raw = yaml.load(fid, Loader=yaml.Loader)
 
         # validate the yaml
-        schema.cache_validator.validate(raw)
+        schema.validate(schema.CacheValidator, raw)
 
         # verify that the root path exists
         path = pathlib.Path(os.path.expandvars(raw["root"]))

--- a/stackinator/cache.py
+++ b/stackinator/cache.py
@@ -12,7 +12,7 @@ def configuration_from_file(file, mount):
         raw = yaml.load(fid, Loader=yaml.Loader)
 
         # validate the yaml
-        schema.validate(schema.CacheValidator, raw)
+        schema.CacheValidator.validate(raw)
 
         # verify that the root path exists
         path = pathlib.Path(os.path.expandvars(raw["root"]))

--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -1,6 +1,5 @@
 import copy
 import pathlib
-from textwrap import dedent
 
 import jinja2
 import yaml
@@ -248,37 +247,6 @@ class Recipe:
 
         with config_path.open() as fid:
             raw = yaml.load(fid, Loader=yaml.Loader)
-
-            # check config version
-            rversion = raw.get("version", 1)
-            if rversion != 2:
-                if rversion == 1:
-                    self._logger.error(
-                        dedent("""
-                               The recipe is an old version 1 recipe for Spack v0.23 and earlier.
-                               This version of Stackinator supports Spack 1.0, and has deprecated support for Spack v0.23.
-                               Use version 5 of stackinator, which can be accessed via the releases/v5 branch:
-                               git switch releases/v5
-
-                               If this recipe is to be used with Spack 1.0, then please add the field 'version: 2' to
-                               config.yaml in your recipe.
-
-                               For more information: https://eth-cscs.github.io/stackinator/recipes/#configuration
-                               """)
-                    )
-                    raise RuntimeError("incompatible uenv recipe version")
-                else:
-                    self._logger.error(
-                        dedent(f"""
-                               The config.yaml file sets an unknown recipe version={rversion}.
-                               This version of Stackinator supports version 2 recipes.
-
-                               For more information: https://eth-cscs.github.io/stackinator/recipes/#configuration
-                               """)
-                    )
-                    raise RuntimeError("incompatible uenv recipe version")
-
-            # validate config against schema
             schema.ConfigValidator.validate(raw)
             self._config = raw
 

--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -68,7 +68,7 @@ class Recipe:
 
         with compiler_path.open() as fid:
             raw = yaml.load(fid, Loader=yaml.Loader)
-            schema.validate(schema.CompilersValidator, raw)
+            schema.CompilersValidator.validate(raw)
             self.generate_compiler_specs(raw)
 
         # required environments.yaml file
@@ -89,7 +89,7 @@ class Recipe:
                 "specs": ["squashfs"],
                 "views": {},
             }
-            schema.validate(schema.EnvironmentsValidator, raw)
+            schema.EnvironmentsValidator.validate(raw)
             self.generate_environment_specs(raw)
 
         # optional modules.yaml file
@@ -279,7 +279,7 @@ class Recipe:
                     raise RuntimeError("incompatible uenv recipe version")
 
             # validate config against schema
-            schema.validate(schema.ConfigValidator, raw)
+            schema.ConfigValidator.validate(raw)
             self._config = raw
 
     # In Stackinator 6 we replaced logic required to determine the

--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -89,7 +89,7 @@ class Recipe:
 
         with compiler_path.open() as fid:
             raw = yaml.load(fid, Loader=yaml.Loader)
-            schema.compilers_validator.validate(raw)
+            schema.validate(schema.CompilersValidator, raw)
             self.generate_compiler_specs(raw)
 
         # required environments.yaml file
@@ -110,7 +110,7 @@ class Recipe:
                 "specs": ["squashfs"],
                 "views": {},
             }
-            schema.environments_validator.validate(raw)
+            schema.validate(schema.EnvironmentsValidator, raw)
             self.generate_environment_specs(raw)
 
         # optional modules.yaml file
@@ -269,7 +269,7 @@ class Recipe:
 
         with config_path.open() as fid:
             raw = yaml.load(fid, Loader=yaml.Loader)
-            schema.config_validator.validate(raw)
+            schema.validate(schema.ConfigValidator, raw)
             self._config = raw
 
     # In Stackinator 6 we replaced logic required to determine the

--- a/stackinator/schema.py
+++ b/stackinator/schema.py
@@ -58,7 +58,7 @@ def validator_from_schemafile(schema_filepath):
 
 
 class ValidationError(jsonschema.ValidationError):
-    def __init__(self, name: str, errors: [jsonschema.ValidationError]):
+    def __init__(self, name: str, errors: list[jsonschema.ValidationError]):
         assert len(errors) != 0
         messages = [
             f"- Failed validating '{error.validator}' in {error.json_path} : {error.message}" for error in errors
@@ -68,13 +68,14 @@ class ValidationError(jsonschema.ValidationError):
         super().__init__(message)
 
 
-def validate(schema_validator, instance):
+def validate(schema_validator: jsonschema.protocols.Validator, instance: dict):
     """
     Validate an instance of a schema against a given schema_validator class.
 
     :raises ValidationError: if the instance is invalid
     """
     errors = [error for error in schema_validator.iter_errors(instance)]
+
     if len(errors) != 0:
         raise ValidationError(schema_validator.schema.get("title", "no-title"), errors)
 

--- a/stackinator/schema.py
+++ b/stackinator/schema.py
@@ -6,33 +6,6 @@ import yaml
 
 prefix = pathlib.Path(__file__).parent.resolve()
 
-# create a validator that will insert optional fields with their default values
-# if they have not been provided.
-
-
-def extend_with_default(validator_class):
-    validate_properties = validator_class.VALIDATORS["properties"]
-
-    def set_defaults(validator, properties, instance, schema):
-        # if instance is none, it's not possible to set any default for any sub-property
-        if instance is not None:
-            for property, subschema in properties.items():
-                if "default" in subschema:
-                    instance.setdefault(property, subschema["default"])
-
-        for error in validate_properties(
-            validator,
-            properties,
-            instance,
-            schema,
-        ):
-            yield error
-
-    return jsonschema.validators.extend(
-        validator_class,
-        {"properties": set_defaults},
-    )
-
 
 def py2yaml(data, indent):
     dump = yaml.dump(data)
@@ -41,14 +14,63 @@ def py2yaml(data, indent):
     return res
 
 
-validator = extend_with_default(jsonschema.Draft7Validator)
+def validator(schema):
+    """
+    Create a new validator class that will insert optional fields with their default values
+    if they have not been provided.
+    """
 
-# load recipe yaml schema
-config_schema = json.load(open(prefix / "schema/config.json"))
-config_validator = validator(config_schema)
-compilers_schema = json.load(open(prefix / "schema/compilers.json"))
-compilers_validator = validator(compilers_schema)
-environments_schema = json.load(open(prefix / "schema/environments.json"))
-environments_validator = validator(environments_schema)
-cache_schema = json.load(open(prefix / "schema/cache.json"))
-cache_validator = validator(cache_schema)
+    def extend_with_default(validator_class):
+        validate_properties = validator_class.VALIDATORS["properties"]
+
+        def set_defaults(validator, properties, instance, schema):
+            # if instance is none, it's not possible to set any default for any sub-property
+            if instance is not None:
+                for property, subschema in properties.items():
+                    if "default" in subschema:
+                        instance.setdefault(property, subschema["default"])
+
+            for error in validate_properties(
+                validator,
+                properties,
+                instance,
+                schema,
+            ):
+                yield error
+
+        return jsonschema.validators.extend(
+            validator_class,
+            {"properties": set_defaults},
+        )
+
+    # try to read dialect metaschema from the $schema entry, otherwise fallback to a default one.
+    metaschema = jsonschema.validators.validator_for(schema)
+
+    return extend_with_default(metaschema)(schema)
+
+
+def validator_from_schemafile(schema_filepath):
+    """
+    Create a new validator class given the schema filepath.
+    See validator function for details.
+    """
+    return validator(json.load(open(schema_filepath)))
+
+
+def validate(schema_validator, instance):
+    """
+    Validate an instance of a schema against a given schema_validator class.
+
+    It prints all errors detected during validation and then it raises the first one.
+    """
+    errors = [error for error in schema_validator.iter_errors(instance)]
+    if len(errors) != 0:
+        for error in errors:
+            print(error.json_path, error.message)
+        raise errors[0]
+
+
+ConfigValidator = validator_from_schemafile(prefix / "schema/config.json")
+CompilersValidator = validator_from_schemafile(prefix / "schema/compilers.json")
+EnvironmentsValidator = validator_from_schemafile(prefix / "schema/environments.json")
+CacheValidator = validator_from_schemafile(prefix / "schema/cache.json")

--- a/unittests/recipes/base-nvgpu/config.yaml
+++ b/unittests/recipes/base-nvgpu/config.yaml
@@ -5,3 +5,4 @@ spack:
     commit: 6408b51
 mirror:
     enable: false
+version: 2

--- a/unittests/recipes/cache/config.yaml
+++ b/unittests/recipes/cache/config.yaml
@@ -6,3 +6,4 @@ spack:
 mirror:
   key: /scratch/e1000/bcumming/secret/spack-key.gpg
   enable: true
+version: 2

--- a/unittests/recipes/host-recipe/config.yaml
+++ b/unittests/recipes/host-recipe/config.yaml
@@ -4,4 +4,4 @@ description: "An example gcc configuration for CPU-only development"
 spack:
   commit: releases/v0.23
   repo: https://github.com/spack/spack.git
-
+version: 2

--- a/unittests/recipes/with-repo/config.yaml
+++ b/unittests/recipes/with-repo/config.yaml
@@ -3,3 +3,4 @@ store: '/user-environment'
 spack:
     repo: https://github.com/spack/spack.git
     commit: v21.0
+version: 2

--- a/unittests/test_schema.py
+++ b/unittests/test_schema.py
@@ -38,7 +38,7 @@ def test_config_yaml(yaml_path):
     # test that the defaults are set as expected
     with open(yaml_path / "config.defaults.yaml") as fid:
         raw = yaml.load(fid, Loader=yaml.Loader)
-        schema.validator(schema.config_schema).validate(raw)
+        schema.validate(schema.ConfigValidator, raw)
         assert raw["store"] == "/user-environment"
         assert raw["spack"]["commit"] is None
         assert raw["modules"] == True  # noqa: E712
@@ -47,7 +47,7 @@ def test_config_yaml(yaml_path):
 
     with open(yaml_path / "config.full.yaml") as fid:
         raw = yaml.load(fid, Loader=yaml.Loader)
-        schema.validator(schema.config_schema).validate(raw)
+        schema.validate(schema.ConfigValidator, raw)
         assert raw["store"] == "/alternative-point"
         assert raw["spack"]["commit"] == "6408b51"
         assert raw["modules"] == False  # noqa: E712
@@ -60,20 +60,20 @@ def test_recipe_config_yaml(recipe_paths):
     for p in recipe_paths:
         with open(p / "config.yaml") as fid:
             raw = yaml.load(fid, Loader=yaml.Loader)
-            schema.validator(schema.config_schema).validate(raw)
+            schema.validate(schema.ConfigValidator, raw)
 
 
 def test_compilers_yaml(yaml_path):
     # test that the defaults are set as expected
     with open(yaml_path / "compilers.defaults.yaml") as fid:
         raw = yaml.load(fid, Loader=yaml.Loader)
-        schema.validator(schema.compilers_schema).validate(raw)
+        schema.validate(schema.CompilersValidator, raw)
         assert raw["gcc"] == {"version": "10.2"}
         assert raw["llvm"] is None
 
     with open(yaml_path / "compilers.full.yaml") as fid:
         raw = yaml.load(fid, Loader=yaml.Loader)
-        schema.validator(schema.compilers_schema).validate(raw)
+        schema.validate(schema.CompilersValidator, raw)
         assert raw["gcc"] == {"version": "11"}
         assert raw["llvm"] == {"version": "13"}
         assert raw["nvhpc"] == {"version": "25.1"}
@@ -84,13 +84,13 @@ def test_recipe_compilers_yaml(recipe_paths):
     for p in recipe_paths:
         with open(p / "compilers.yaml") as fid:
             raw = yaml.load(fid, Loader=yaml.Loader)
-            schema.validator(schema.compilers_schema).validate(raw)
+            schema.validate(schema.CompilersValidator, raw)
 
 
 def test_environments_yaml(yaml_path):
     with open(yaml_path / "environments.full.yaml") as fid:
         raw = yaml.load(fid, Loader=yaml.Loader)
-        schema.validator(schema.environments_schema).validate(raw)
+        schema.validate(schema.EnvironmentsValidator, raw)
 
         # the defaults-env does not set fields
         # test that they have been set to the defaults correctly
@@ -136,7 +136,7 @@ def test_environments_yaml(yaml_path):
             jsonschema.exceptions.ValidationError,
             match=r"Additional properties are not allowed \('providers' was unexpected",
         ):
-            schema.validator(schema.environments_schema).validate(raw)
+            schema.validate(schema.EnvironmentsValidator, raw)
 
 
 def test_recipe_environments_yaml(recipe_paths):
@@ -144,4 +144,4 @@ def test_recipe_environments_yaml(recipe_paths):
     for p in recipe_paths:
         with open(p / "environments.yaml") as fid:
             raw = yaml.load(fid, Loader=yaml.Loader)
-            schema.validator(schema.environments_schema).validate(raw)
+            schema.validate(schema.EnvironmentsValidator, raw)

--- a/unittests/test_schema.py
+++ b/unittests/test_schema.py
@@ -38,7 +38,7 @@ def test_config_yaml(yaml_path):
     # test that the defaults are set as expected
     with open(yaml_path / "config.defaults.yaml") as fid:
         raw = yaml.load(fid, Loader=yaml.Loader)
-        schema.validate(schema.ConfigValidator, raw)
+        schema.ConfigValidator.validate(raw)
         assert raw["store"] == "/user-environment"
         assert raw["spack"]["commit"] is None
         assert raw["modules"] == True  # noqa: E712
@@ -47,7 +47,7 @@ def test_config_yaml(yaml_path):
 
     with open(yaml_path / "config.full.yaml") as fid:
         raw = yaml.load(fid, Loader=yaml.Loader)
-        schema.validate(schema.ConfigValidator, raw)
+        schema.ConfigValidator.validate(raw)
         assert raw["store"] == "/alternative-point"
         assert raw["spack"]["commit"] == "6408b51"
         assert raw["modules"] == False  # noqa: E712
@@ -60,20 +60,20 @@ def test_recipe_config_yaml(recipe_paths):
     for p in recipe_paths:
         with open(p / "config.yaml") as fid:
             raw = yaml.load(fid, Loader=yaml.Loader)
-            schema.validate(schema.ConfigValidator, raw)
+            schema.ConfigValidator.validate(raw)
 
 
 def test_compilers_yaml(yaml_path):
     # test that the defaults are set as expected
     with open(yaml_path / "compilers.defaults.yaml") as fid:
         raw = yaml.load(fid, Loader=yaml.Loader)
-        schema.validate(schema.CompilersValidator, raw)
+        schema.CompilersValidator.validate(raw)
         assert raw["gcc"] == {"version": "10.2"}
         assert raw["llvm"] is None
 
     with open(yaml_path / "compilers.full.yaml") as fid:
         raw = yaml.load(fid, Loader=yaml.Loader)
-        schema.validate(schema.CompilersValidator, raw)
+        schema.CompilersValidator.validate(raw)
         assert raw["gcc"] == {"version": "11"}
         assert raw["llvm"] == {"version": "13"}
         assert raw["nvhpc"] == {"version": "25.1"}
@@ -84,13 +84,13 @@ def test_recipe_compilers_yaml(recipe_paths):
     for p in recipe_paths:
         with open(p / "compilers.yaml") as fid:
             raw = yaml.load(fid, Loader=yaml.Loader)
-            schema.validate(schema.CompilersValidator, raw)
+            schema.CompilersValidator.validate(raw)
 
 
 def test_environments_yaml(yaml_path):
     with open(yaml_path / "environments.full.yaml") as fid:
         raw = yaml.load(fid, Loader=yaml.Loader)
-        schema.validate(schema.EnvironmentsValidator, raw)
+        schema.EnvironmentsValidator.validate(raw)
 
         # the defaults-env does not set fields
         # test that they have been set to the defaults correctly
@@ -136,7 +136,7 @@ def test_environments_yaml(yaml_path):
             jsonschema.exceptions.ValidationError,
             match=r"Additional properties are not allowed \('providers' was unexpected",
         ):
-            schema.validate(schema.EnvironmentsValidator, raw)
+            schema.EnvironmentsValidator.validate(raw)
 
 
 def test_recipe_environments_yaml(recipe_paths):
@@ -144,4 +144,4 @@ def test_recipe_environments_yaml(recipe_paths):
     for p in recipe_paths:
         with open(p / "environments.yaml") as fid:
             raw = yaml.load(fid, Loader=yaml.Loader)
-            schema.validate(schema.EnvironmentsValidator, raw)
+            schema.EnvironmentsValidator.validate(raw)

--- a/unittests/test_schema.py
+++ b/unittests/test_schema.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import pathlib
+from textwrap import dedent
 
 import jsonschema
 import pytest
@@ -53,6 +54,16 @@ def test_config_yaml(yaml_path):
         assert raw["modules"] == False  # noqa: E712
         assert raw["mirror"] == {"enable": True, "key": "/home/bob/veryprivate.key"}
         assert raw["description"] == "a really useful environment"
+
+    # unsupported old version
+    with pytest.raises(RuntimeError, match="incompatible uenv recipe version"):
+        config = dedent("""
+        name: cuda-env
+        spack:
+            repo: https://github.com/spack/spack.git
+        """)
+        raw = yaml.load(config, Loader=yaml.Loader)
+        schema.ConfigValidator.validate(raw)
 
 
 def test_recipe_config_yaml(recipe_paths):

--- a/unittests/yaml/config.defaults.yaml
+++ b/unittests/yaml/config.defaults.yaml
@@ -12,3 +12,4 @@ spack:
     #enable: True
 # default True
 #modules: True
+version: 2

--- a/unittests/yaml/config.full.yaml
+++ b/unittests/yaml/config.full.yaml
@@ -8,3 +8,4 @@ mirror:
     enable: True
 modules: False
 description: "a really useful environment"
+version: 2


### PR DESCRIPTION
Close #247

**Rationale:**
Current version of stackinator does not support older versions of `config.yaml` (as stated by the error message reported below), so I don't see the point in having a back-compatible schema (like I was trying with #247).

https://github.com/eth-cscs/stackinator/blob/a4db2ee7d8bd0355f8082fe8405a48c0226b0099/stackinator/recipe.py#L58-L67

**Proposal:**
the schema should support just the current supported version, same for tests which should just care about currently supported version (at most, check that unsupported version are correctly reported with a user-friendly error message).

**Changelog:**
- move version check logic as a pre-check in the validation step
- adapt tests and test resources to `version: 2`
- took the chance to customize the error message (more in following comment)