### PR TITLE
First class network stack support

### DIFF
--- a/docs/cluster-config.md
+++ b/docs/cluster-config.md
@@ -3,11 +3,12 @@
 Spack stacks are built on bare-metal clusters using a minimum of dependencies from the underlying system.
 A cluster configuration is a directory with the following structure:
 
+TODO: document layout of the `network.yaml` file
+
 ```
 /path/to/cluster/configuration
-├─ compilers.yaml   # system compiler
 ├─ packages.yaml    # external system packages
-├─ concretiser.yaml
+├─ network.yaml     # configuration options for network libraries
 └─ repos.yaml       # optional reference to additional site packages
 ```
 
@@ -51,9 +52,8 @@ This is designed to make it encourage putting cluster definitions and the site d
 ```
 /path/to/cluster-configs
 ├─ my_cluster
-│   ├─ compilers.yaml
 │   ├─ packages.yaml
-│   ├─ concretiser.yaml
+│   ├─ network.yaml
 │   └─ repos.yaml    # refers to ../site/repo
 └─ site
    └─ repo           # the site wide repo

--- a/docs/cluster-config.md
+++ b/docs/cluster-config.md
@@ -50,7 +50,7 @@ packages:
     * The `specs` field for `mpi:cray-mpich:specs` and `mpi:openmpi:specs` fields set different default `libfabric` for the respective MPI distributions.
     * By default `packages:cray-mpich` and `packages:openmpi` add the `+cuda` variant as a preference to build with cuda support by default on the Grace-Hopper nodes.
         * This can be overriden by adding `~cuda` to the spec in `network:mpi` in your recipe.
-    * The version of `libfabric` on tye system is `1.22.0`, but it is set as buildable so that it can be build from source by Spack if a different (more recent) verson is selected in a recipe.
+    * The version of `libfabric` on the system is `1.22.0`, but it is set as buildable so that it can be built from source by Spack if a different (more recent) version is selected in a recipe.
     * A combination of `require` and `prefer` are used in the `packages` definitions to enforce settings and set defaults, respectively.
 
     ```yaml title="network.yaml"

--- a/docs/cluster-config.md
+++ b/docs/cluster-config.md
@@ -46,7 +46,7 @@ packages:
     openmpi:   ...
 ```
 
-??? example "example `network.yaml` for grace hopper"
+??? example "example `network.yaml` for Grace Hopper"
     * The `specs` field for `mpi:cray-mpich:specs` and `mpi:openmpi:specs` fields set different default `libfabric` for the respective MPI distributions.
     * By default `packages:cray-mpich` and `packages:openmpi` add the `+cuda` variant as a preference to build with cuda support by default on the Grace-Hopper nodes.
         * This can be overriden by adding `~cuda` to the spec in `network:mpi` in your recipe.

--- a/docs/porting.md
+++ b/docs/porting.md
@@ -98,7 +98,10 @@ Because of this, the compiler description is greatly streamlined.
           version: "25.1"
         ```
 
+[](){#ref-porting-network}
 ## `environments.yaml`
+
+TODO: document `mpi` -> `network` field.
 
 The main change in `environments.yaml` is how the compiler toolchain is specified.
 The compilers are provided as a list, without version information.

--- a/docs/porting.md
+++ b/docs/porting.md
@@ -101,10 +101,16 @@ Because of this, the compiler description is greatly streamlined.
 [](){#ref-porting-network}
 ## `environments.yaml`
 
-TODO: document `mpi` -> `network` field.
+There are two significant changes to the `environments.yaml` file that need to be made:
 
-The main change in `environments.yaml` is how the compiler toolchain is specified.
-The compilers are provided as a list, without version information.
+1. the description of MPI and its dependencies
+1. the description of compilers
+
+The good news that in both cases it is simpler than before.
+
+### Specifying compilers
+
+Compilers are now described as a list, without version information.
 
 !!! example "a gcc based uenv"
     This uenv uses `gcc@13` as the only compiler.
@@ -173,6 +179,32 @@ Avoid specifying the compiler to use for `cray-mpich`, because this conflicts wi
       - hdf5+mpi+hl+fortran %fortran=nvhpc
     ```
     This will transitively require that `cray-mpich` be installed using `nvhpc`.
+
+### Specifying MPI, libfabric and friends
+
+In order to make it easier to build cray-mpich, OpenMPI or MPICH, and have greater control over dependencies like libfabric with Spack 1.0, the interface has changed.
+The `mpi:` field is gone, and in its place there is a `network:` field.
+
+!!! example "cray-mpich with cuda support"
+    === "Stackinator 5"
+
+        ```yaml title="environments.yaml"
+        mpi:
+          spec: cray-mpich@8.1.30
+          gpu: cuda
+        ```
+
+    === "Stackinator 6"
+
+        ```yaml title="environments.yaml"
+        network:
+          mpi: cray-mpich@8.1.30 +cuda
+        ```
+
+    If building on a system with NVIDIA GPUs, the `+cuda` option is probably selected by default.
+    See the `mpi:cray-mpich` and `packages:cray-mpich` fields for the `network.yaml` file in the cluster configuration to see the defaults.
+
+
 
 ## `modules.yaml`
 

--- a/docs/porting.md
+++ b/docs/porting.md
@@ -201,7 +201,7 @@ The `mpi:` field is gone, and in its place there is a `network:` field.
           mpi: cray-mpich@8.1.30 +cuda
         ```
 
-    If building on a system with NVIDIA GPUs, the `+cuda` option is probably selected by default.
+    If building on a system with NVIDIA GPUs, the `+cuda` option is selected by default.
     See the `mpi:cray-mpich` and `packages:cray-mpich` fields for the `network.yaml` file in the cluster configuration to see the defaults.
 
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -231,7 +231,7 @@ See the [`network.yaml` documentation][ref-cluster-config-network] for more info
 
 !!! alps
 
-    The recommended MPI distribution on Alps is `cray-mpich`, as it is the most widely tested MPI for the libfabric/slingshot network.
+    The recommended MPI distribution on Alps is `cray-mpich`, as it is the most widely tested MPI for the libfabric/Slingshot network.
 
     OpenMPI's support for the Slingshot network is improving, however it may not be optimal for many applications, or requires more effort to fine tune.
     As such, it is recommended as an option for applications that have performance issues or bugs with cray-mpich.

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -187,7 +187,7 @@ The `network` field has a field for defining MPI and additional custom package d
     ```yaml title="environments.yaml"
     network:
       mpi: openmpi@5.0.8
-      specs: ['libfabric@1.2.2']
+      specs: ['libfabric@2.2.0']
     ```
 
 It is only possible to have a single MPI implementation in an environment, specified through the `mpi` field.

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -168,14 +168,14 @@ The `network` field has a field for defining MPI and additional custom package d
 
 !!! example "cray-mpich"
 
-    Rely on the defaults for the target system system:
+    Rely on the defaults for the target system:
     ```yaml title="environments.yaml"
     network:
       mpi: cray-mpich
     ```
 
     Provide a more explicit spec that disables `cuda` (this might be useful on a system where `cuda` support is the default).
-    Also request a specific version of
+    Also request a specific version of `libfabric`
     ```yaml title="environments.yaml"
     network:
       mpi: cray-mpich@9.0 ~cuda
@@ -191,7 +191,7 @@ The `network` field has a field for defining MPI and additional custom package d
     ```
 
 It is only possible to have a single MPI implementation in an environment, specified through the `mpi` field.
-Behind the scenes, Stackinator adds a hard requirement that all packages in the environment use the the chosen MPI, to help Spack concretise correctly.
+Behind the scenes, Stackinator adds a hard requirement that all packages in the environment use the chosen MPI, to help Spack concretise correctly.
 
 ??? question "How do I provide cray-mpich and openmpi in my uenv?"
     No problem!
@@ -201,7 +201,7 @@ Behind the scenes, Stackinator adds a hard requirement that all packages in the 
     mpich:
         compilers: [gcc]
         network:
-          mpi: openmpi@5.0.8
+          mpi: cray-mpich
           specs: ['libfabric@1.2.2']
         specs:
           - hdf5+mpi+fortran
@@ -224,7 +224,7 @@ Behind the scenes, Stackinator adds a hard requirement that all packages in the 
 
 
 The `network.yaml` file in the cluster config provides a set of default specs for MPI dependencies for each MPI distribution.
-See the [`network.yaml` documenation][ref-cluster-config-network] for more information about how the defaults are set.
+See the [`network.yaml` documentation][ref-cluster-config-network] for more information about how the defaults are set.
 
 ??? question "Why add a `network:specs` field instead of just adding `libfabric` and friends to the main `specs` list?"
     It is easier to override these by providing a custom field for network dependencies.

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -155,12 +155,7 @@ Stackinator can configure MPI (cray-mpich and OpenMPI) its dependencies (libfabr
     The `network` field replaces the `mpi` field in Stackinator 6.
     See the [porting guide][ref-porting-network] for guidance on updating uenv recipes for Spack 1.0.
 
-If the `network` field is not set, or is set to `null`, MPI will not be configured in an environment:
-
-```yaml title="environments.yaml no network/mpi stack"
-serial-env:
-  network: null
-```
+If the `network` field is not set, MPI will not be configured in an environment.
 
 The `network` field has a field for defining MPI and additional custom package definitions
 
@@ -180,7 +175,7 @@ The `network` field has a field for defining MPI and additional custom package d
     ```
 
     Provide a more explicit spec that disables `cuda` (this might be useful on a system where `cuda` support is the default).
-    Also request a specific version of `libfabric`
+    Also request a specific version of
     ```yaml title="environments.yaml"
     network:
       mpi: cray-mpich@9.0 ~cuda
@@ -198,7 +193,7 @@ The `network` field has a field for defining MPI and additional custom package d
 It is only possible to have a single MPI implementation in an environment, specified through the `mpi` field.
 Behind the scenes, Stackinator adds a hard requirement that all packages in the environment use the the chosen MPI, to help Spack concretise correctly.
 
-??? tip "but I want to provide cray-mpich and openmpi in my uenv"
+??? question "How do I provide cray-mpich and openmpi in my uenv?"
     No problem!
     Just add two environments in your `environments.yaml` file, for example:
 
@@ -227,8 +222,11 @@ Behind the scenes, Stackinator adds a hard requirement that all packages in the 
 
     The uenv will provide two views for the end user.
 
-!!! question "Why add a `network:specs` field instead of just adding `libfabric` and friends to the main `specs` list"
-    The `network.yaml` file in the cluster config provides a set of default specs for MPI dependencies for each MPI distribution.
+
+The `network.yaml` file in the cluster config provides a set of default specs for MPI dependencies for each MPI distribution.
+See the [`network.yaml` documenation][ref-cluster-config-network] for more information about how the defaults are set.
+
+??? question "Why add a `network:specs` field instead of just adding `libfabric` and friends to the main `specs` list?"
     It is easier to override these by providing a custom field for network dependencies.
 
 !!! alps
@@ -238,12 +236,6 @@ Behind the scenes, Stackinator adds a hard requirement that all packages in the 
     OpenMPI's support for the Slingshot network is improving, however it may not be optimal for many applications, or requires more effort to fine tune.
     As such, it is recommended as an option for applications that have performance issues or bugs with cray-mpich.
 
-
-
-
-#### Custimsing network dependences with specs
-
-You can provide
 
 ### Specs
 

--- a/stackinator/main.py
+++ b/stackinator/main.py
@@ -87,7 +87,7 @@ def main():
         )
         return 0
     except Exception as e:
-        root_logger.debug(traceback.format_exc())
+        root_logger.info(traceback.format_exc())
         root_logger.error(str(e))
         root_logger.info(f"see {logfile} for more information")
         return 1

--- a/stackinator/main.py
+++ b/stackinator/main.py
@@ -87,7 +87,7 @@ def main():
         )
         return 0
     except Exception as e:
-        root_logger.info(traceback.format_exc())
+        root_logger.debug(traceback.format_exc())
         root_logger.error(str(e))
         root_logger.info(f"see {logfile} for more information")
         return 1

--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -324,7 +324,9 @@ class Recipe:
                     if match:
                         mpi_name = match.group(1)
                         if mpi_name not in ("cray-mpich", "openmpi"):
-                            raise Exception(f"{mpi_name} is not a supported MPI version: try one of cray-mpich or openmpi.")
+                            raise Exception(
+                                f"{mpi_name} is not a supported MPI version: try one of cray-mpich or openmpi."
+                            )
                     else:
                         raise Exception(f"{spec} is not a valid MPI spec")
 

--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -335,7 +335,6 @@ class Recipe:
                     elif self.mpi_templates[mpi_name]["specs"]:
                         specs += self.mpi_templates[mpi_name]["specs"]
 
-                    specs.append(spec)
                     environments[name]["mpi"] = mpi_name
                     environments[name]["specs"] += specs
 

--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -325,9 +325,7 @@ class Recipe:
                         mpi_name = match.group(1)
                         supported_mpis = [k for k in self.mpi_templates.keys()]
                         if mpi_name not in supported_mpis:
-                            raise Exception(
-                                f"{mpi_name} is not a supported MPI version: try one of {supported_mpis}."
-                            )
+                            raise Exception(f"{mpi_name} is not a supported MPI version: try one of {supported_mpis}.")
                     else:
                         raise Exception(f"{spec} is not a valid MPI spec")
 

--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -142,7 +142,7 @@ class Recipe:
             # currently we only need squashfs for creating the squashfs file.
             raw["uenv_tools"] = {
                 "compiler": ["gcc"],
-                "network": None,
+                "network": {"mpi": None, "specs": None},
                 "unify": True,
                 "deprecated": False,
                 "specs": ["squashfs"],

--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -121,7 +121,7 @@ class Recipe:
                     mpi_templates = raw["mpi"]
         self.mpi_templates = mpi_templates
 
-        # note that the order that package sets are sepcified in is significant.
+        # note that the order that package sets are specified in is significant.
         # arguments to the right have higher precedence.
         self.packages = {
             # the package definition used in every environment

--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -8,16 +8,6 @@ from . import cache, root_logger, schema, spack_util
 
 
 class Recipe:
-    valid_mpi_specs = {
-        "cray-mpich": (None, None),
-        "mpich": ("4.1", "device=ch4 netmod=ofi +slurm"),
-        "mvapich2": (
-            "3.0a",
-            "+xpmem fabrics=ch4ofi ch4_max_vcis=4 process_managers=slurm",
-        ),
-        "openmpi": ("5", "+internal-pmix +legacylaunchers +orterunprefix fabrics=cma,ofi,xpmem schedulers=slurm"),
-    }
-
     @property
     def path(self):
         """the path of the recipe"""
@@ -92,27 +82,6 @@ class Recipe:
             schema.compilers_validator.validate(raw)
             self.generate_compiler_specs(raw)
 
-        # required environments.yaml file
-        environments_path = self.path / "environments.yaml"
-        self._logger.debug(f"opening {environments_path}")
-        if not environments_path.is_file():
-            raise FileNotFoundError(f"The recipe path '{environments_path}' does not contain environments.yaml")
-
-        with environments_path.open() as fid:
-            raw = yaml.load(fid, Loader=yaml.Loader)
-            # add a special environment that installs tools required later in the build process.
-            # currently we only need squashfs for creating the squashfs file.
-            raw["uenv_tools"] = {
-                "compiler": ["gcc"],
-                "mpi": None,
-                "unify": True,
-                "deprecated": False,
-                "specs": ["squashfs"],
-                "views": {},
-            }
-            schema.environments_validator.validate(raw)
-            self.generate_environment_specs(raw)
-
         # optional modules.yaml file
         modules_path = self.path / "modules.yaml"
         self._logger.debug(f"opening {modules_path}")
@@ -157,12 +126,51 @@ class Recipe:
         else:
             raise RuntimeError("The system packages.yaml file does not provide gcc")
 
+        # load the optional network.yaml from system config:
+        # - meta data about mpi
+        # - package information for network libraries (libfabric, openmpi, cray-mpich, ... etc)
+        network_path = self.system_config_path / "network.yaml"
+        self._logger.debug(f"opening {network_path}")
+        network_packages = {}
+        mpi_templates = {}
+        if network_path.is_file():
+            with network_path.open() as fid:
+                raw = yaml.load(fid, Loader=yaml.Loader)
+                if "packages" in raw:
+                    network_packages = raw["packages"]
+                if "mpi" in raw:
+                    mpi_templates = raw["mpi"]
+        self.mpi_templates = mpi_templates
+
+        # note that the order that package sets are sepcified in is significant.
+        # arguments to the right have higher precedence.
         self.packages = {
             # the package definition used in every environment
-            "global": {"packages": system_packages | recipe_packages},
+            "global": {"packages": system_packages | network_packages | recipe_packages},
             # the package definition used to build gcc (requires system gcc to bootstrap)
             "gcc": {"packages": system_packages | gcc_packages | recipe_packages},
         }
+
+        # required environments.yaml file
+        environments_path = self.path / "environments.yaml"
+        self._logger.debug(f"opening {environments_path}")
+        if not environments_path.is_file():
+            raise FileNotFoundError(f"The recipe path '{environments_path}' does not contain environments.yaml")
+
+        with environments_path.open() as fid:
+            raw = yaml.load(fid, Loader=yaml.Loader)
+            # add a special environment that installs tools required later in the build process.
+            # currently we only need squashfs for creating the squashfs file.
+            raw["uenv_tools"] = {
+                "compiler": ["gcc"],
+                "network": None,
+                "unify": True,
+                "deprecated": False,
+                "specs": ["squashfs"],
+                "views": {},
+            }
+            schema.environments_validator.validate(raw)
+            self.generate_environment_specs(raw)
 
         # optional mirror configurtion
         mirrors_path = self.path / "mirrors.yaml"
@@ -314,38 +322,58 @@ class Recipe:
             if ("specs" not in config) or (config["specs"] is None):
                 environments[name]["specs"] = []
 
-            if "mpi" not in config:
-                environments[name]["mpi"] = {"spec": None, "gpu": None}
-
-        # complete configuration of MPI in each environment
+        # Complete configuration of MPI in each environment
+        # this involves generate specs for the chosen MPI implementation
+        # and (optionally) additional dependencies like libfabric, which are
+        # appended to the list of specs in the environment.
         for name, config in environments.items():
-            if config["mpi"]:
-                mpi = config["mpi"]
-                mpi_spec = mpi["spec"]
-                mpi_gpu = mpi["gpu"]
-                if mpi_spec:
-                    try:
-                        mpi_impl, mpi_ver = mpi_spec.strip().split(sep="@", maxsplit=1)
-                    except ValueError:
-                        mpi_impl = mpi_spec.strip()
-                        mpi_ver = None
+            # the "mpi" entry records the name of the MPI implementation used by the environment.
+            # set it to none by default, and have it set if the config["network"] description specifies
+            # an MPI implementation.
+            environments[name]["mpi"] = None
 
-                    if mpi_impl in Recipe.valid_mpi_specs:
-                        default_ver, options = Recipe.valid_mpi_specs[mpi_impl]
-                        if mpi_ver:
-                            version_opt = f"@{mpi_ver}"
-                        else:
-                            version_opt = f"@{default_ver}" if default_ver else ""
+            if config["network"]:
+                # we will build a list of additional specs related to MPI, libfabric, etc to add to the list of specs
+                # in the generated spack.yaml file.
+                # start with an empty list:
+                specs = []
 
-                        spec = f"{mpi_impl}{version_opt} {options or ''}".strip()
+                mpi = None
+                mpi_name = None
+                if "cray-mpich" in config["network"]:
+                    mpi = config["network"]["cray-mpich"]
+                    mpi_name = "cray-mpich"
+                elif "openmpi" in config["network"]:
+                    if mpi is not None:
+                        raise Exception("only one MPI implementation can be selected in an environment")
+                    mpi = config["network"]["openmpi"]
+                    mpi_name = "openmpi"
 
-                        if mpi_gpu:
-                            spec = f"{spec} +{mpi_gpu}"
-
-                        environments[name]["specs"].append(spec)
+                if mpi is not None:
+                    if isinstance(mpi, str):
+                        # a literal spec was provided
+                        specs.append(mpi)
                     else:
-                        # TODO: Create a custom exception type
-                        raise Exception(f"Unsupported mpi: {mpi_impl}")
+                        # the user has specified a set of configuration options to convert into a spec
+                        if (not self.mpi_templates) and (mpi_name not in self.mpi_templates):
+                            raise Exception(
+                                "the network configuration for the target system has no template for {mpi_name}"
+                            )
+                        template = self.mpi_templates[mpi_name]
+                        gpu = f"+{template['gpu']}" if template["gpu"] else ""
+                        version = f"@{template['version']}" if template["version"] else ""
+                        mpi_spec = template["spec"].format(gpu=gpu, version=version)
+                        specs.append(mpi_spec)
+
+                    # if the recipe provided explicit specs for dependencies, inject them:
+                    if config["network"]["specs"]:
+                        specs += config["network"]["specs"]
+                    # otherwise inject dependencies from network.yaml (if they exist)
+                    elif self.mpi_templates[mpi_name]["specs"]:
+                        specs += self.mpi_templates[mpi_name]["specs"]
+
+                    environments[name]["mpi"] = mpi_name
+                    environments[name]["specs"] += specs
 
         # set constraints that ensure the the main compiler is always used to build packages
         # that do not explicitly request a compiler.

--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -323,9 +323,10 @@ class Recipe:
                     match = re.match(r"^([A-Za-z][A-Za-z0-9_-]*)", spec)
                     if match:
                         mpi_name = match.group(1)
-                        if mpi_name not in ("cray-mpich", "openmpi"):
+                        supported_mpis = [k for k in self.mpi_templates.keys()]
+                        if mpi_name not in supported_mpis:
                             raise Exception(
-                                f"{mpi_name} is not a supported MPI version: try one of cray-mpich or openmpi."
+                                f"{mpi_name} is not a supported MPI version: try one of {supported_mpis}."
                             )
                     else:
                         raise Exception(f"{spec} is not a valid MPI spec")

--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -109,10 +109,10 @@ class Recipe:
         # - meta data about mpi
         # - package information for network libraries (libfabric, openmpi, cray-mpich, ... etc)
         network_path = self.system_config_path / "network.yaml"
-        self._logger.debug(f"opening {network_path}")
         network_packages = {}
         mpi_templates = {}
         if network_path.is_file():
+            self._logger.debug(f"opening {network_path}")
             with network_path.open() as fid:
                 raw = yaml.load(fid, Loader=yaml.Loader)
                 if "packages" in raw:

--- a/stackinator/schema/environments.json
+++ b/stackinator/schema/environments.json
@@ -47,59 +47,23 @@
                     "default": null
                  },
                  "network": {
-                     "oneOf": [
-                         {
-                             "type": "object",
-                             "cray-mpich": {
-                                 "oneOf": [
-                                     {
-                                         "type": "object",
-                                         "additionalProperties": false,
-                                         "properties": {
-                                             "version": {"type": "string"},
-                                             "gpu":  {
-                                                 "enum": ["cuda", "rocm", null, false],
-                                                 "default": null
-                                             }
-                                         }
-                                     },
-                                     {
-                                         "type": "string"
-                                     },
-                                     {
-                                         "type": "null"
-                                     }
-                                 ],
-                                 "default": null
-                             },
-                             "openmpi": {
-                                 "oneOf": [
-                                     {
-                                         "type": "object",
-                                         "additionalProperties": false,
-                                         "properties": {
-                                             "version": {"type": "string"},
-                                             "gpu":  {
-                                                 "enum": ["cuda", "rocm", null, false],
-                                                 "default": null
-                                             }
-                                         }
-                                     },
-                                     {
-                                         "type": "string"
-                                     }
-                                 ],
-                                 "default": null
-                             },
-                             "specs": {
-                                 "type": "array",
-                                 "items": {"type": "string"},
-                                 "default": []
-                             }
+                     "type": "object",
+                     "additionalProperties": false,
+                     "default": {"mpi": null, "specs": []},
+                     "properties": {
+                         "mpi": {
+                             "oneOf": [
+                                 { "type": "string" },
+                                 { "type": "null" }
+                             ],
+                             "default": null
                          },
-                         {"type": "null"}
-                     ],
-                     "defalt": null
+                         "specs": {
+                             "type": "array",
+                             "items": {"type": "string"},
+                             "default": []
+                         }
+                     }
                  },
                  "packages": {
                      "type": "array",

--- a/stackinator/schema/environments.json
+++ b/stackinator/schema/environments.json
@@ -46,22 +46,60 @@
                     ],
                     "default": null
                  },
-                 "mpi": {
+                 "network": {
                      "oneOf": [
                          {
                              "type": "object",
-                             "additionalProperties": false,
-                             "properties": {
-                                 "spec": {"type": "string"},
-                                 "gpu":  {
-                                     "enum": ["cuda", "rocm", null, false],
-                                     "default": null
-                                 }
+                             "cray-mpich": {
+                                 "oneOf": [
+                                     {
+                                         "type": "object",
+                                         "additionalProperties": false,
+                                         "properties": {
+                                             "version": {"type": "string"},
+                                             "gpu":  {
+                                                 "enum": ["cuda", "rocm", null, false],
+                                                 "default": null
+                                             }
+                                         }
+                                     },
+                                     {
+                                         "type": "string"
+                                     },
+                                     {
+                                         "type": "null"
+                                     }
+                                 ],
+                                 "default": null
+                             },
+                             "openmpi": {
+                                 "oneOf": [
+                                     {
+                                         "type": "object",
+                                         "additionalProperties": false,
+                                         "properties": {
+                                             "version": {"type": "string"},
+                                             "gpu":  {
+                                                 "enum": ["cuda", "rocm", null, false],
+                                                 "default": null
+                                             }
+                                         }
+                                     },
+                                     {
+                                         "type": "string"
+                                     }
+                                 ],
+                                 "default": null
+                             },
+                             "specs": {
+                                 "type": "array",
+                                 "items": {"type": "string"},
+                                 "default": []
                              }
                          },
-                         {"enum": [null, false]}
+                         {"type": "null"}
                      ],
-                     "default": null
+                     "defalt": null
                  },
                  "packages": {
                      "type": "array",
@@ -116,6 +154,6 @@
                  }
              }
          }
-     }
+    }
 }
 

--- a/stackinator/schema/environments.json
+++ b/stackinator/schema/environments.json
@@ -49,7 +49,7 @@
                  "network": {
                      "type": "object",
                      "additionalProperties": false,
-                     "default": {"mpi": null, "specs": []},
+                     "default": {"mpi": null, "specs": null},
                      "properties": {
                          "mpi": {
                              "oneOf": [
@@ -59,9 +59,14 @@
                              "default": null
                          },
                          "specs": {
-                             "type": "array",
-                             "items": {"type": "string"},
-                             "default": []
+                             "oneOf": [
+                                 {
+                                     "type": "array",
+                                     "items": {"type": "string"}
+                                 },
+                                 {"type": "null"}
+                             ],
+                             "default": null
                          }
                      }
                  },

--- a/stackinator/templates/environments.spack.yaml
+++ b/stackinator/templates/environments.spack.yaml
@@ -11,7 +11,7 @@ spack:
 {% for spec in config.specs %}
   - '{{ spec }}'
 {% endfor %}
-{% if config.prefer or config.variants or config.mpi.spec %}
+{% if config.prefer or config.variants or config.mpi %}
   packages:
 {% if config.prefer or config.variants %}
     all:
@@ -24,9 +24,9 @@ spack:
       variants: [{% for v in config.variants %}{{ separator() }}'{{ v }}'{% endfor %}]
     {% endif %}
 {% endif %}
-    {% if config.mpi.spec %}
+    {% if config.mpi %}
     mpi:
-      require: '{{ config.mpi.spec }}'
+      require: '{{ config.mpi }}'
     {% endif %}
 {% endif %}
 {% if config.view %}

--- a/unittests/recipes/base-nvgpu/environments.yaml
+++ b/unittests/recipes/base-nvgpu/environments.yaml
@@ -4,9 +4,8 @@ gcc-env:
   specs:
   - cuda@11.8
   - osu-micro-benchmarks@5.9
-  mpi:
-    spec: cray-mpich
-    gpu: cuda
+  network:
+    mpi: cray-mpich+cuda
   variants:
     - +mpi
     - +cuda

--- a/unittests/recipes/cache/environments.yaml
+++ b/unittests/recipes/cache/environments.yaml
@@ -3,9 +3,9 @@ gcc-env:
   unify: true
   specs:
   - fmt
-  mpi:
-    spec: cray-mpich
-    gpu: false
+  network:
+    mpi: cray-mpich ~cuda
+    specs: []
 tools:
   compiler: [gcc]
   unify: true

--- a/unittests/recipes/host-recipe/environments.yaml
+++ b/unittests/recipes/host-recipe/environments.yaml
@@ -8,9 +8,8 @@ gcc-env:
   - python@3.10
   - tree
   - libtree
-  mpi:
-    spec: cray-mpich
-    gpu: false
+  network:
+    mpi: cray-mpich
   views:
     default:
     run:

--- a/unittests/recipes/with-repo/environments.yaml
+++ b/unittests/recipes/with-repo/environments.yaml
@@ -4,9 +4,8 @@ gcc-env:
   specs:
   - osu-micro-benchmarks@5.9
   - hdf5 +mpi
-  mpi:
-    spec: cray-mpich
-    gpu: false
+  network:
+    mpi: cray-mpich
 tools:
   compiler: [gcc]
   unify: true

--- a/unittests/test_schema.py
+++ b/unittests/test_schema.py
@@ -5,6 +5,7 @@ from textwrap import dedent
 
 import jsonschema
 import pytest
+import pprint
 import yaml
 
 import stackinator.schema as schema
@@ -148,6 +149,10 @@ def test_environments_yaml(yaml_path):
         raw = yaml.load(fid, Loader=yaml.Loader)
         schema.EnvironmentsValidator.validate(raw)
 
+        print("===========================================================================")
+        pprint.pp(raw)
+        print("===========================================================================")
+
         # the defaults-env does not set fields
         # test that they have been set to the defaults correctly
 
@@ -162,12 +167,11 @@ def test_environments_yaml(yaml_path):
         assert env["unify"] == True  # noqa: E712
         assert env["packages"] == []
         assert env["variants"] == []
-        assert env["mpi"] is None
+        assert env["network"] == {"mpi": None, "specs": []}
         assert env["views"] == {}
 
         env = raw["defaults-env-mpi-nogpu"]
-        assert env["mpi"]["spec"] is not None
-        assert env["mpi"]["gpu"] is None
+        assert env["network"]["mpi"] == "cray-mpich"
 
         # the full-env sets all of the fields
         # test that they have been read correctly
@@ -176,11 +180,11 @@ def test_environments_yaml(yaml_path):
         env = raw["full-env"]
         assert env["compiler"] == ["gcc"]
         assert env["specs"] == ["osu-micro-benchmarks@5.9", "hdf5 +mpi"]
+        assert env["network"] == {"mpi": "cray-mpich +cuda", "specs": ["libfabric@2.2.0"]}
 
         # test defaults were set correctly
         assert env["unify"] == "when_possible"
         assert env["packages"] == ["perl", "git"]
-        assert env["mpi"] == {"spec": "cray-mpich", "gpu": "cuda"}
         assert env["variants"] == ["+mpi", "+cuda"]
         assert env["views"] == {"default": None}
 

--- a/unittests/test_schema.py
+++ b/unittests/test_schema.py
@@ -167,7 +167,7 @@ def test_environments_yaml(yaml_path):
         assert env["unify"] == True  # noqa: E712
         assert env["packages"] == []
         assert env["variants"] == []
-        assert env["network"] == {"mpi": None, "specs": []}
+        assert env["network"] == {"mpi": None, "specs": None}
         assert env["views"] == {}
 
         env = raw["defaults-env-mpi-nogpu"]

--- a/unittests/test_schema.py
+++ b/unittests/test_schema.py
@@ -5,7 +5,6 @@ from textwrap import dedent
 
 import jsonschema
 import pytest
-import pprint
 import yaml
 
 import stackinator.schema as schema
@@ -148,10 +147,6 @@ def test_environments_yaml(yaml_path):
     with open(yaml_path / "environments.full.yaml") as fid:
         raw = yaml.load(fid, Loader=yaml.Loader)
         schema.EnvironmentsValidator.validate(raw)
-
-        print("===========================================================================")
-        pprint.pp(raw)
-        print("===========================================================================")
 
         # the defaults-env does not set fields
         # test that they have been set to the defaults correctly

--- a/unittests/yaml/environments.err-providers.yaml
+++ b/unittests/yaml/environments.err-providers.yaml
@@ -4,9 +4,8 @@ full-env:
   specs:
   - osu-micro-benchmarks@5.9
   - hdf5 +mpi
-  mpi:
-    spec: cray-mpich
-    gpu: cuda
+  network:
+    mpi: cray-mpich +cuda
   packages:
   - perl
   - git

--- a/unittests/yaml/environments.full.yaml
+++ b/unittests/yaml/environments.full.yaml
@@ -4,9 +4,9 @@ full-env:
   specs:
   - osu-micro-benchmarks@5.9
   - hdf5 +mpi
-  mpi:
-    spec: cray-mpich
-    gpu: cuda
+  network:
+    mpi: cray-mpich +cuda
+    specs: ["libfabric@2.2.0"]
   packages:
   - perl
   - git
@@ -21,12 +21,12 @@ defaults-env:
   - tree
   # assert variants=[]
   # assert unify=True
-  # assert mpi=None
+  # assert network={"mpi": None, "specs": []}
   # assert packages=[]
   # assert view=True
 defaults-env-mpi-nogpu:
   compiler: [gcc]
   specs:
   - tree
-  mpi:
-    spec: cray-mpich
+  network:
+    mpi: cray-mpich

--- a/unittests/yaml/environments.full.yaml
+++ b/unittests/yaml/environments.full.yaml
@@ -21,7 +21,7 @@ defaults-env:
   - tree
   # assert variants=[]
   # assert unify=True
-  # assert network={"mpi": None, "specs": []}
+  # assert network={"mpi": None, "specs": None}
   # assert packages=[]
   # assert view=True
 defaults-env-mpi-nogpu:


### PR DESCRIPTION
The method for adding MPI and tuning the networking libarary stack has been simplified.

There are two components that define the network stack.
The first is the new `network` field in `environments.yaml` that replaces the old `mpi` field.
The user provides a `spec` for the MPI distribution they want (currently cray-mpich and openmpi are supported), and an optional list of specs for dependencies (e.g. libfabric):

```yaml
network:
  mpi: <spec>
  specs: [<spec>, ...]
```

The other half is the new `network.yaml` file in the system configuration, that provides a default list of `specs` for each MPI distribution, and a `packages.yaml` description of the default / required variants and options for cray-mpich, openmpi, libfabric, etc.

For example, using this approach, the `+cuda` variant can be set as a default on a GH200 cluster, and disabled on a CPU-only system.

Based off #210.