### PR TITLE
Reduce the number of Spack environments

### DIFF
--- a/stackinator/templates/Makefile.environments
+++ b/stackinator/templates/Makefile.environments
@@ -32,10 +32,10 @@ all:{% for env in environments %} {{ env }}/generated/build_cache{% endfor %}
 # Create environment view where requested
 {% for env, config in environments.items() %}
 {{ env }}/generated/view_config: {{ env }}/generated/env
-{% if config.view %}
-	$(SPACK) env activate --with-view default --sh ./{{ env }} > $(STORE)/env/{{ config.view.name }}/activate.sh
-	$(BUILD_ROOT)/envvars.py view {% if config.view.extra.add_compilers %}--compilers=./{{ env }}/packages.yaml {% endif %} --prefix_paths="{{ config.view.extra.prefix_string }}" $(STORE)/env/{{ config.view.name }} $(BUILD_ROOT)
-{% endif %}
+{% for view in config.views %}
+	$(SPACK) env activate --with-view {{ view.name }} --sh ./{{ env }} > $(STORE)/env/{{ view.name }}/activate.sh
+	$(BUILD_ROOT)/envvars.py view {% if view.extra.add_compilers %}--compilers=./{{ env }}/packages.yaml {% endif %} --prefix_paths="{{ view.extra.prefix_string }}" $(STORE)/env/{{ view.name }} $(BUILD_ROOT)
+{% endfor %}
 	touch $@
 
 {% endfor %}

--- a/stackinator/templates/environments.spack.yaml
+++ b/stackinator/templates/environments.spack.yaml
@@ -29,10 +29,12 @@ spack:
       require: '{{ config.mpi }}'
     {% endif %}
 {% endif %}
-{% if config.view %}
+{% if config.views %}
   view:
-    default:
-      {{ config.view.config|py2yaml(6) }}
+{% for view in config.views %}
+    {{ view.name }}:
+      {{ view.config|py2yaml(6) }}
+{% endfor %}
 {% else %}
   view: false
 {% endif %}


### PR DESCRIPTION
Remove a long-standing work around to an old Spack bug, that required us to generate a separate Spack environment for every view.
This meant that if an `environments.yaml` recipe contained more than one view in an environment (e.g. `default` and `develop`), then the environment would be concretised twice.

Spack 1.0 fixes this issue, so we can .

This has no impact on users or recipes, it is a back end optimization.

Fixes #209 