### PR TITLE
minor: improve error management for missing system gcc compiler in system configuration

### DIFF
--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -129,7 +129,7 @@ class Recipe:
 
         # extract gcc packages from system packages
         # remove gcc from packages afterwards
-        if system_packages["gcc"]:
+        if "gcc" in system_packages:
             gcc_packages = {"gcc": system_packages["gcc"]}
             del system_packages["gcc"]
         else:


### PR DESCRIPTION
In the cluster configuration the file `packages.yaml` is optional

https://github.com/eth-cscs/stackinator/blob/5581430ce63f5ecfd5dae8e59b578e145b7767cf/stackinator/recipe.py#L91-L98

but at the same time there is an implicit requirement since if there is no `gcc` specified in `packages.yaml`, we should raise an exception.

https://github.com/eth-cscs/stackinator/blob/5581430ce63f5ecfd5dae8e59b578e145b7767cf/stackinator/recipe.py#L100-L106

With this small PR, the `RuntimeError` with a nicer and a bit more informative error message will be raised also in case no `packages.yaml` or it is available but no `gcc` is specified.



note: I faced this many times when by mistake I ended up passing the wrong path for the cluster configuration, and the path didn't contain the "usual" yaml files.