### PR TITLE
Use real path for `<build_dir>/spack/bin` paths

### DIFF
--- a/docs/build-caches.md
+++ b/docs/build-caches.md
@@ -97,5 +97,5 @@ When debugging a recipe, where failing builds have to be run multiple times, the
 To force push all packages that have been built, use the `cache-force` makefile target:
 
 ```bash
-env --ignore-environment PATH=/usr/bin:/bin:`pwd`/spack/bin make cache-force
+env --ignore-environment PATH=/usr/bin:/bin:`pwd -P`/spack/bin make cache-force
 ```

--- a/docs/building.md
+++ b/docs/building.md
@@ -12,7 +12,7 @@ stack-config --build $BUILD_PATH ...
 
 # perform the build
 cd $BUILD_PATH
-env --ignore-environment PATH=/usr/bin:/bin:`pwd`/spack/bin make modules store.squashfs -j32
+env --ignore-environment PATH=/usr/bin:/bin:`pwd -P`/spack/bin make modules store.squashfs -j32
 ```
 
 The call to `make` is wrapped with with `env --ignore-env` to unset all environment variables, to improve reproducability of builds.

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,7 +55,7 @@ Once configured, the build stack is built in the build path using make:
 ```bash
 # build the spack stack
 cd $BUILD_PATH
-env --ignore-environment PATH=/usr/bin:/bin:`pwd`/spack/bin make modules store.squashfs -j64
+env --ignore-environment PATH=/usr/bin:/bin:`pwd -P`/spack/bin make modules store.squashfs -j64
 ```
 
 See the documentation on [building Spack stacks](building.md) for more information.

--- a/stackinator/main.py
+++ b/stackinator/main.py
@@ -83,7 +83,7 @@ def main():
         root_logger.info("\nConfiguration finished, run the following to build the environment:\n")
         root_logger.info(f"cd {builder.path}")
         root_logger.info(
-            "env --ignore-environment PATH=/usr/bin:/bin:`pwd`/spack/bin HOME=$HOME make store.squashfs -j32"
+            "env --ignore-environment PATH=/usr/bin:/bin:`pwd -P`/spack/bin HOME=$HOME make store.squashfs -j32"
         )
         return 0
     except Exception as e:


### PR DESCRIPTION
If build dir is a symbolic link in a directory that is not mounted when `bwrap` is executed the `make` call will fail with:

```
bwrap: execvp spack: No such file or directory
make: *** [Makefile:9: spack-version] Error 1
```

Adding the `-P` option to the `pwd` command fixes this issue.