### PR TITLE
remove unused entries in mirrors.yaml

### DIFF
--- a/stackinator/cache.py
+++ b/stackinator/cache.py
@@ -47,15 +47,9 @@ def generate_mirrors_yaml(config):
             "alpscache": {
                 "fetch": {
                     "url": f"file://{path}",
-                    "access_pair": [None, None],
-                    "profile": None,
-                    "endpoint_url": None,
                 },
                 "push": {
                     "url": f"file://{path}",
-                    "access_pair": [None, None],
-                    "profile": None,
-                    "endpoint_url": None,
                 },
             }
         }


### PR DESCRIPTION
the schema for `mirrors.yaml` has been changed in `spack@develop` giving an error on `access_pairs`. Remove `access_pair`, `profile`, `endpoint_url` (`=None`) from the template. Tested with spack `releases/v1.0` and `develop` branch.