### PR TITLE
Measure time of all concretization steps

### DIFF
--- a/stackinator/etc/Make.inc
+++ b/stackinator/etc/Make.inc
@@ -17,7 +17,7 @@ store:
 
 # Concretization
 %/spack.lock: %/spack.yaml %/config.yaml %/packages.yaml
-	/usr/bin/time -f "\"%C\" took %e seconds." $(SPACK_ENV) concretize -f
+	/usr/bin/time -f '"%C" took %e seconds.' $(SPACK_ENV) concretize -f
 
 # Generate Makefiles for the environment install
 %/Makefile: %/spack.lock

--- a/stackinator/etc/Make.inc
+++ b/stackinator/etc/Make.inc
@@ -17,7 +17,7 @@ store:
 
 # Concretization
 %/spack.lock: %/spack.yaml %/config.yaml %/packages.yaml
-	$(SPACK_ENV) concretize -f
+	/usr/bin/time -f "\"%C\" took %e seconds." $(SPACK_ENV) concretize -f
 
 # Generate Makefiles for the environment install
 %/Makefile: %/spack.lock


### PR DESCRIPTION
It is a very small and marginal change, but it might be helpful/interesting in certain situations knowing how much a concretization step took.


Just as an example, this is how it looks like.

```
/usr/bin/time -f "\"%C\" took %e seconds." spack -e uenv_tools/ concretize -f
==> Concretized 1 spec:
 -   ndag2eb  squashfs@4.6.1+gzip~lz4~lzo~static~xz~zstd build_system=makefile default_compression=gzip platform=linux os=sles15 target=neoverse_v2 %c=gcc@14.2.0
[+]  hcns3gf      ^compiler-wrapper@1.0 build_system=generic platform=linux os=sles15 target=neoverse_v2
[e]  f6ia2r5      ^gcc@14.2.0~binutils+bootstrap~graphite~mold~nvptx~piclibs~profiled~strip build_system=autotools build_type=RelWithDebInfo languages:='c,c++,fortran' platform=linux os=sles15 target=aarch64
 -   c3kepa7      ^gcc-runtime@14.2.0 build_system=generic platform=linux os=sles15 target=neoverse_v2
[e]  3dm7s3r      ^glibc@2.31 build_system=autotools platform=linux os=sles15 target=aarch64
 -   mkn24at      ^gmake@4.4.1~guile build_system=generic platform=linux os=sles15 target=neoverse_v2 %c=gcc@14.2.0
 -   isykha5      ^zlib-ng@2.2.4+compat+new_strategies+opt+pic+shared build_system=autotools platform=linux os=sles15 target=neoverse_v2 %c,cxx=gcc@14.2.0
[+]  3uhzjpc          ^gnuconfig@2024-07-27 build_system=generic platform=linux os=sles15 target=neoverse_v2

"spack -e uenv_tools/ concretize -f" took 30.76 seconds.
```

Mainly
- concretization command is prefixed with the `time` command along with the output format
- it uses `/usr/bin/time` instead of the shell builtin, so that a custom format can be specified
- additional line for the message after the concretization step with the time measured