### PR TITLE
Add support for `llvm-amdgpu` as compiler

### DIFF
--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -463,6 +463,15 @@ class Recipe:
             llvm["exclude_from_cache"] = cache_exclude
             compilers["llvm"] = llvm
 
+        if raw["llvm-amdgpu"] is not None:
+            llvm_amdgpu = {}
+            llvm_amdgpu_version = raw["llvm-amdgpu"]["version"]
+            llvm_amdgpu["packages"] = False
+            llvm_amdgpu["specs"] = [f"llvm-amdgpu@{llvm_amdgpu_version}"]
+
+            llvm_amdgpu["exclude_from_cache"] = cache_exclude
+            compilers["llvm-amdgpu"] = llvm_amdgpu
+
         self.compilers = compilers
 
     # The path of the default configuration for the target system/cluster

--- a/stackinator/schema/compilers.json
+++ b/stackinator/schema/compilers.json
@@ -44,6 +44,22 @@
                 }
             ],
             "default": null
+        },
+        "llvm-amdgpu": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "version": {"type": "string"}
+                    },
+                    "additionalProperties": false,
+                    "required": ["version"]
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "default": null
         }
     }
 }

--- a/stackinator/schema/environments.json
+++ b/stackinator/schema/environments.json
@@ -50,7 +50,7 @@
                      "type": "array",
                      "items": {
                          "type": "string",
-                         "enum": ["gcc", "nvhpc", "llvm"]
+                         "enum": ["gcc", "nvhpc", "llvm", "llvm-amdgpu"]
                      }
                  },
                  "specs": {

--- a/stackinator/templates/Makefile.compilers
+++ b/stackinator/templates/Makefile.compilers
@@ -46,6 +46,11 @@ llvm/packages.yaml: gcc/generated/env
 	$(SPACK) compiler find --scope=user $(call compiler_bin_dirs, $$($(SPACK_HELPER) -e ./gcc find --explicit --format '{prefix}' {{ compilers.llvm.requires }}))
 {% endif %}
 
+{% if compilers.get('llvm-amdgpu') %}
+llvm-amdgpu/packages.yaml: gcc/generated/env
+	$(SPACK) compiler find --scope=user $(call compiler_bin_dirs, $$($(SPACK_HELPER) -e ./gcc find --explicit --format '{prefix}' {{ compilers.get('llvm-amdgpu').requires }}))
+{% endif %}
+
 {% if compilers.nvhpc %}
 nvhpc/packages.yaml: gcc/generated/env
 	$(SPACK) compiler find --scope=user $(call compiler_bin_dirs, $$($(SPACK_HELPER) -e ./gcc find --explicit --format '{prefix}' {{ compilers.nvhpc.requires }}))
@@ -63,6 +68,12 @@ include gcc/Makefile
 {% if compilers.llvm %}
 ifneq (,$(wildcard gcc/Makefile))
 include llvm/Makefile
+endif
+{% endif %}
+
+{% if compilers.get('llvm-amdgpu') %}
+ifneq (,$(wildcard gcc/Makefile))
+include llvm-amdgpu/Makefile
 endif
 {% endif %}
 

--- a/stackinator/templates/Makefile.generate-config
+++ b/stackinator/templates/Makefile.generate-config
@@ -4,10 +4,10 @@ CONFIG_DIR = $(STORE)/config
 MODULE_DIR = $(BUILD_ROOT)/modules
 
 # These will be the prefixes of the GCCs, LLVMs and NVHPCs in the respective environments.
-ALL_COMPILER_PREFIXES ={% for compiler in all_compilers %} $$($(SPACK_HELPER) -e ../compilers/{{ compiler }} find --explicit --format='{prefix}' gcc llvm nvhpc){% endfor %}
+ALL_COMPILER_PREFIXES ={% for compiler in all_compilers %} $$($(SPACK_HELPER) -e ../compilers/{{ compiler }} find --explicit --format='{prefix}' gcc llvm llvm-amdgpu nvhpc){% endfor %}
 
 
-COMPILER_PREFIXES ={% for compiler in release_compilers %} $$($(SPACK_HELPER) -e ../compilers/{{ compiler }} find --explicit --format='{prefix}' gcc llvm nvhpc){% endfor %}
+COMPILER_PREFIXES ={% for compiler in release_compilers %} $$($(SPACK_HELPER) -e ../compilers/{{ compiler }} find --explicit --format='{prefix}' gcc llvm llvm-amdgpu nvhpc){% endfor %}
 
 
 all: $(CONFIG_DIR)/upstreams.yaml $(CONFIG_DIR)/packages.yaml $(CONFIG_DIR)/repos.yaml $(MODULE_DIR)/upstreams.yaml $(MODULE_DIR)/compilers.yaml

--- a/unittests/yaml/compilers.full.yaml
+++ b/unittests/yaml/compilers.full.yaml
@@ -4,3 +4,5 @@ llvm:
   version: "13"
 nvhpc:
   version: "25.1"
+llvm-amdgpu:
+  version: "6.3"


### PR DESCRIPTION
This is useful to be able to build `rccl-tests` which wants to be built with `llvm-amdgpu` (cf. https://github.com/spack/spack-packages/pull/2212).

The use of `compilers.get('llvm-amdgpu')` in the jinja templates is because `compilers.llvm-amdgpu` is interpreted as "access the `llvm` key of `compilers`.