### PR TITLE
Add missing `llvm-amdgpu` template file

### DIFF
--- a/stackinator/templates/compilers.llvm-amdgpu.spack.yaml
+++ b/stackinator/templates/compilers.llvm-amdgpu.spack.yaml
@@ -1,0 +1,13 @@
+spack:
+  include:
+  - packages.yaml
+  - config.yaml
+  specs:
+{% for spec in config.specs %}
+  - {{ spec }}
+{% endfor %}
+  view: false
+  concretizer:
+    unify: when_possible
+    reuse: false
+


### PR DESCRIPTION
I left out the template file for llvm-amdgpu in #268. This PR adds that file.