### PR TITLE
highlight warnings and errors

### DIFF
--- a/stackinator/main.py
+++ b/stackinator/main.py
@@ -33,10 +33,31 @@ def generate_logfile_name(name=""):
 def configure_logging(logfile):
     root_logger.setLevel(logging.DEBUG)
 
+    class ColoredFormatter(logging.Formatter):
+        # ANSI escape codes (CSI Control Sequence Introducer)
+        COLORS = {
+            logging.WARNING: "\033[1;33m",
+            logging.ERROR: "\033[1;31m",
+            logging.CRITICAL: "\033[1;41m",
+        }
+        RESET = "\033[0m"
+
+        def format(self, record):
+            message = super().format(record)
+
+            # Prepend level name for warnings and above
+            if record.levelno >= logging.WARNING:
+                message = f"{record.levelname}: {message}"
+
+            # Apply color based on log level
+            color = self.COLORS.get(record.levelno, self.RESET)
+
+            return f"{color}{message}{self.RESET}"
+
     # create stdout handler and set level to info
     ch = logging.StreamHandler(stream=sys.stdout)
     ch.setLevel(logging.INFO)
-    ch.setFormatter(logging.Formatter("%(message)s"))
+    ch.setFormatter(ColoredFormatter())
     root_logger.addHandler(ch)
 
     # create log file handler and set level to debug


### PR DESCRIPTION
Follow up of https://github.com/eth-cscs/alps-uenv/pull/276#issuecomment-3646830309, covering just the "colored" part for highlighting messages.

<img width="1724" height="1012" alt="image" src="https://github.com/user-attachments/assets/ae005447-449d-43c2-98a2-1a385d465b48" />
<img width="1734" height="1034" alt="image" src="https://github.com/user-attachments/assets/113b9a00-9188-41b9-9c75-9515aae146e9" />
