### PR TITLE
bin/stack-config: avoid .venv arch conflicts by having separate venvs for each arch

### DIFF
--- a/bin/stack-config
+++ b/bin/stack-config
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
+export UV_PROJECT_ENVIRONMENT=.venv-`uname -m`
+
 STACKINATOR_ROOT=$(dirname `realpath $0`)/..
 uv run --directory $STACKINATOR_ROOT --with . python -m stackinator.main $@


### PR DESCRIPTION
Use `UV_PROJECT_ENVIRONMENT` https://docs.astral.sh/uv/concepts/projects/config/#project-environment-path to differentiate .venv folder depending on the arch.