### PR TITLE
bin/stack-config: fix bug about relative path to recipes + minor changes and doc

### DIFF
--- a/bin/stack-config
+++ b/bin/stack-config
@@ -5,8 +5,7 @@ STACKINATOR_ROOT=$(dirname `realpath $0`)/..
 
 # Notes:
 # - --project: make `uv run` run in "project" mode, using the specified project directory
-# - --with-editable: install the project in editable mode, so that changes to the source code are reflected immediately without needing to reinstall
 # - UV_PROJECT_ENVIRONMENT: specify a custom name for the project virtual environment, based on the architecture (avoiding conflicts between x86_64 and arm64)
 
 export UV_PROJECT_ENVIRONMENT=.venv-`uname -m`
-uv run --project $STACKINATOR_ROOT --with-editable $STACKINATOR_ROOT python -m stackinator.main $@
+uv run --project $STACKINATOR_ROOT stack-config $@

--- a/bin/stack-config
+++ b/bin/stack-config
@@ -5,7 +5,8 @@ STACKINATOR_ROOT=$(dirname `realpath $0`)/..
 
 # Notes:
 # - --project: make `uv run` run in "project" mode, using the specified project directory
+# - --with-editable: install the project in editable mode, so that changes to the source code are reflected immediately without needing to reinstall
 # - UV_PROJECT_ENVIRONMENT: specify a custom name for the project virtual environment, based on the architecture (avoiding conflicts between x86_64 and arm64)
 
 export UV_PROJECT_ENVIRONMENT=.venv-`uname -m`
-uv run --project $STACKINATOR_ROOT --with $STACKINATOR_ROOT python -m stackinator.main $@
+uv run --project $STACKINATOR_ROOT --with-editable $STACKINATOR_ROOT python -m stackinator.main $@

--- a/bin/stack-config
+++ b/bin/stack-config
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
-export UV_PROJECT_ENVIRONMENT=.venv-`uname -m`
-
+# determine the root directory of the stackinator project
 STACKINATOR_ROOT=$(dirname `realpath $0`)/..
-uv run --directory $STACKINATOR_ROOT --with . python -m stackinator.main $@
+
+# Notes:
+# - --project: make `uv run` run in "project" mode, using the specified project directory
+# - UV_PROJECT_ENVIRONMENT: specify a custom name for the project virtual environment, based on the architecture (avoiding conflicts between x86_64 and arm64)
+
+export UV_PROJECT_ENVIRONMENT=.venv-`uname -m`
+uv run --project $STACKINATOR_ROOT --with $STACKINATOR_ROOT python -m stackinator.main $@


### PR DESCRIPTION
This PR fixes a bug where a user specifying a relative folder as argument, resulted in a path relative to the project folder instead of relative to the user working directory.

Changes:
- move from `--directory` to `--project`, hence we don't alter user working directory when using this script (resulting in wrong behavior from the user point of view), but we just point `uv run` so that it is in "project mode"
- move from a simple installation to an "editable installation" using `--with-editable`, so that changes in the project folder are directly reflected
- took the chance to document the various parts of the script for future reference.