### PR TITLE
Feature/source mirrors

### DIFF
--- a/stackinator/builder.py
+++ b/stackinator/builder.py
@@ -232,6 +232,8 @@ class Builder:
                     pre_install_hook=recipe.pre_install_hook,
                     spack_version=spack_version,
                     spack_meta=spack_meta,
+                    # pass source_mirrors to Makefile render
+                    source_mirrors=recipe.config.get("source_mirrors", {}),
                     exclude_from_cache=["nvhpc", "cuda", "perl"],
                     verbose=False,
                 )

--- a/stackinator/schema/config.json
+++ b/stackinator/schema/config.json
@@ -64,6 +64,13 @@
                 }
             }
         },
+        "source_mirrors" : {
+            "type" : "object",
+            "additionalProperties": {
+                "type" : "string"
+            },
+            "default": {}
+        },
         "modules" : {
             "type": "boolean"
         },

--- a/stackinator/templates/Makefile
+++ b/stackinator/templates/Makefile
@@ -34,22 +34,20 @@ pre-install: spack-setup
 mirror-setup: spack-setup{% if pre_install_hook %} pre-install{% endif %}
 
 	{% if cache %}
-	$(SANDBOX) $(SPACK) buildcache keys --install --trust
-	{% if cache.key %}
-	$(SANDBOX) $(SPACK) gpg trust {{ cache.key }}
-	{% endif %}
-	{% endif %}
-	{% if source_mirrors %}
-	echo "Removing all instances of mirror.spack.io...  Just in case"
-	grep -rl "https://mirror.spack.io" . | xargs sed -i 's|https://mirror.spack.io||g'
-	echo "Adding mirrors"
-	{% for name, url in source_mirrors.items() %}
-	$(SANDBOX) $(SPACK) mirror add {{ name }} {{ url }}
-	{% endfor %}
-	echo "Spack mirrors for this recipe:"
-	spack mirror list
-	{% endif %}
-	touch mirror-setup
+    $(SANDBOX) $(SPACK) buildcache keys --install --trust
+    {% if cache.key %}
+    $(SANDBOX) $(SPACK) gpg trust {{ cache.key }}
+    {% endif %}
+    {% endif %}
+    {% if source_mirrors %}
+    @echo "Adding mirrors"
+    {% for name, url in source_mirrors.items() | reverse %}
+    $(SANDBOX) $(SPACK) mirror add --scope=site {{ name }} {{ url }}
+    {% endfor %}
+    @echo "Current mirror list:"
+    $(SANDBOX) $(SPACK) mirror list
+    {% endif %}
+    touch mirror-setup
 
 compilers: mirror-setup
 	$(SANDBOX) $(MAKE) -C $@

--- a/stackinator/templates/Makefile
+++ b/stackinator/templates/Makefile
@@ -32,22 +32,22 @@ pre-install: spack-setup
 	$(SANDBOX) $(STORE)/pre-install-hook
 
 mirror-setup: spack-setup{% if pre_install_hook %} pre-install{% endif %}
-
+	
 	{% if cache %}
-    $(SANDBOX) $(SPACK) buildcache keys --install --trust
-    {% if cache.key %}
-    $(SANDBOX) $(SPACK) gpg trust {{ cache.key }}
-    {% endif %}
-    {% endif %}
-    {% if source_mirrors %}
-    @echo "Adding mirrors"
-    {% for name, url in source_mirrors.items() | reverse %}
-    $(SANDBOX) $(SPACK) mirror add --scope=site {{ name }} {{ url }}
-    {% endfor %}
-    @echo "Current mirror list:"
-    $(SANDBOX) $(SPACK) mirror list
-    {% endif %}
-    touch mirror-setup
+	$(SANDBOX) $(SPACK) buildcache keys --install --trust
+	{% if cache.key %}
+	$(SANDBOX) $(SPACK) gpg trust {{ cache.key }}
+	{% endif %}
+	{% endif %}
+	{% if source_mirrors %}
+	@echo "Adding mirrors"
+	{% for name, url in source_mirrors.items() | reverse %}
+	$(SANDBOX) $(SPACK) mirror add --scope=site {{ name }} {{ url }}
+	{% endfor %}
+	@echo "Current mirror list:"
+	$(SANDBOX) $(SPACK) mirror list
+	{% endif %}
+	touch mirror-setup
 
 compilers: mirror-setup
 	$(SANDBOX) $(MAKE) -C $@

--- a/stackinator/templates/Makefile
+++ b/stackinator/templates/Makefile
@@ -40,13 +40,13 @@ mirror-setup: spack-setup{% if pre_install_hook %} pre-install{% endif %}
 	{% endif %}
 	{% endif %}
 	{% if source_mirrors %}
-	echo "Replacing all instances of mirror.spack.io...  Just in case"
-	grep -rl "https://mirror.spack.io" . | xargs sed -i 's/https:\/\/mirror.spack.io/https:\/\/pe-serve.lanl.gov\/spack-mirror/g'
+	echo "Removing all instances of mirror.spack.io...  Just in case"
+	grep -rl "https://mirror.spack.io" . | xargs sed -i 's|https://mirror.spack.io||g'
 	echo "Adding mirrors"
 	{% for name, url in source_mirrors.items() %}
 	$(SANDBOX) $(SPACK) mirror add {{ name }} {{ url }}
 	{% endfor %}
-	echo "Current mirror list:"
+	echo "Spack mirrors for this recipe:"
 	spack mirror list
 	{% endif %}
 	touch mirror-setup

--- a/stackinator/templates/Makefile
+++ b/stackinator/templates/Makefile
@@ -39,6 +39,16 @@ mirror-setup: spack-setup{% if pre_install_hook %} pre-install{% endif %}
 	$(SANDBOX) $(SPACK) gpg trust {{ cache.key }}
 	{% endif %}
 	{% endif %}
+	{% if source_mirrors %}
+	echo "Replacing all instances of mirror.spack.io...  Just in case"
+	grep -rl "https://mirror.spack.io" . | xargs sed -i 's/https:\/\/mirror.spack.io/https:\/\/pe-serve.lanl.gov\/spack-mirror/g'
+	echo "Adding mirrors"
+	{% for name, url in source_mirrors.items() %}
+	$(SANDBOX) $(SPACK) mirror add {{ name }} {{ url }}
+	{% endfor %}
+	echo "Current mirror list:"
+	spack mirror list
+	{% endif %}
 	touch mirror-setup
 
 compilers: mirror-setup


### PR DESCRIPTION
Allows users to build from custom spack mirrors. Spack mirrors can be defined in `recipes/config.yaml` like so:
```yaml
source_mirrors:
  <mirror1-name>: <url>
  <mirror2-name>: <url>
```
This will generate a site-scoped spack mirrors.yaml (via `spack mirror add` command in the Makefile) located in `$(BUILD_ROOT)/spack/etc/spack`
```yaml
mirrors:
  mirror1-name: <url>
  mirror2-name: <url>
  spack-public:
    binary: false
    url: https://mirror.spack.io
```
The mirrors have precedence from top to bottom: spack will try to fetch from the first mirror, and will move down the list if the package is not found, defaulting to `spack-public` if none of the user-defined mirrors provide it.