### PR TITLE
Enforce gcc~builtins

### DIFF
--- a/stackinator/templates/compilers.gcc.spack.yaml
+++ b/stackinator/templates/compilers.gcc.spack.yaml
@@ -12,7 +12,7 @@ spack:
     reuse: false
   packages:
     gcc:
-      variants: [build_type=Release +bootstrap +profiled +strip]
+      variants: [build_type=Release +bootstrap +profiled +strip ~binutils]
     mpc:
       variants: [libs=static]
     gmp:


### PR DESCRIPTION
With https://github.com/spack/spack-packages/pull/3106 a default value change for `gcc` variant  `binutils` has been introduced.

This triggers a problem (see [CI error](https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/551234120955960/1440398897047560/-/jobs/13261281018#L447)) when building `binutils`, which by default is built `libs=static,shared` but we explicitly prefer `zstd libs=static`.

https://github.com/eth-cscs/stackinator/blob/c7db13cd3c12d595cf6a7793db88603db9495889/stackinator/templates/compilers.gcc.spack.yaml#L22-L23

The proposed change does not fix the root problem, but it simply prefers building `gcc~builtins` as we've always did, completely workarounding the underlying problem.

I'm going to address the root issue in spack, but for what concerns stackinator, at the moment IMHO this is the most reasonable and simple solution.