### PR TITLE
envvars: drop external python dependencies

### DIFF
--- a/stackinator/etc/envvars.py
+++ b/stackinator/etc/envvars.py
@@ -7,8 +7,6 @@ import re
 from enum import Enum
 from typing import List, Optional
 
-import yaml
-
 
 class EnvVarOp(Enum):
     PREPEND = 1
@@ -504,12 +502,8 @@ def view_impl(args):
     envvars.remove_root(args.build_path)
 
     if args.compilers is not None:
-        if not os.path.isfile(args.compilers):
-            print(f"error - compiler yaml file {args.compilers} does not exist")
-            exit(1)
-
         with open(args.compilers, "r") as file:
-            data = yaml.safe_load(file)
+            data = json.load(file)
 
         compilers = []
         for p in data["packages"].values():

--- a/stackinator/templates/Make.user
+++ b/stackinator/templates/Make.user
@@ -2,6 +2,8 @@
 
 # Copy this file to Make.user and set some variables.
 
+SHELL := bash
+
 # This is the root of the software stack directory.
 BUILD_ROOT := {{ build_path }}
 

--- a/stackinator/templates/Makefile.environments
+++ b/stackinator/templates/Makefile.environments
@@ -34,7 +34,7 @@ all:{% for env in environments %} {{ env }}/generated/build_cache{% endfor %}
 {{ env }}/generated/view_config: {{ env }}/generated/env
 {% for view in config.views %}
 	$(SPACK) env activate --with-view {{ view.name }} --sh ./{{ env }} > $(STORE)/env/{{ view.name }}/activate.sh
-	$(BUILD_ROOT)/envvars.py view {% if view.extra.add_compilers %}--compilers=./{{ env }}/packages.yaml {% endif %} --prefix_paths="{{ view.extra.prefix_string }}" $(STORE)/env/{{ view.name }} $(BUILD_ROOT)
+	$(BUILD_ROOT)/envvars.py view {% if view.extra.add_compilers %}--compilers=<(yq read -j -p v ./{{ env }}/packages.yaml) {% endif %} --prefix_paths="{{ view.extra.prefix_string }}" $(STORE)/env/{{ view.name }} $(BUILD_ROOT)
 {% endfor %}
 	touch $@
 


### PR DESCRIPTION
`envvars.py` is an internal utility used in the build phase of the uenv, where we use the system provided python installation.

Since it is the system provided python installation, we don't have direct control of what dependencies are available, and we can either:
- create a custom managed python venv with required dependencies
- just rely on python standard library

Given that at the moment we just rely on `yaml` as external dep for a single call, I opted for the simplest and less intrusive solution which is the latter option, i.e. dropping this single external dependency.

The first **idea implemented** is to create a temporary file through bash process substitution with `yq` (tool which we already relied on in the past, probably worth forcing/checking its presence) where the yaml file is "translated" to json.

**Why should we care?**
Because if we want to proceed with #273 the problem presented above should be fixed one way or the other.

TODO
- [ ] should we enforce/check yq presence somehow?