### PR TITLE
Use more portable shebangs with `/usr/bin/env bash`

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -566,7 +566,7 @@ The post-install script is templated using Jinja, with the following variables a
 The use of Jinja templates is demonstrated in the following example of a bash script that generates an activation script that adds the installation path of GROMACS to the system PATH:
 
 ```bash title="post-install script that generates a simple activation script."
-#!/bin/bash
+#!/usr/bin/env bash
 
 gmx_path=$(spack -C {{ env.config }} location -i gromacs)/bin
 echo "export PATH=$gmx_path:$PATH" >> {{ env.mount }}/activate.sh

--- a/stackinator/etc/bwrap-mutable-root.sh
+++ b/stackinator/etc/bwrap-mutable-root.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 args=()
 shopt -s dotglob
 for d in /*; do

--- a/stackinator/etc/envvars.py
+++ b/stackinator/etc/envvars.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import json

--- a/unittests/data/arbor-uenv/meta/configure.json
+++ b/unittests/data/arbor-uenv/meta/configure.json
@@ -25,7 +25,7 @@
       "-c",
       "./cache.yaml"
     ],
-    "python": "/usr/bin/python3",
+    "python": "/usr/bin/env python3",
     "version": "4.1.0-dev"
   },
   "time": "20240611 12:06:38"

--- a/unittests/recipes/host-recipe/post-install
+++ b/unittests/recipes/host-recipe/post-install
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "====================================="
 echo "=====     post install hook     ====="

--- a/unittests/recipes/host-recipe/pre-install
+++ b/unittests/recipes/host-recipe/pre-install
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "====================================="
 echo "=====      pre install hook     ====="

--- a/unittests/test-envvars.sh
+++ b/unittests/test-envvars.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 root=$(pwd)
 input_path=${root}/data/arbor-uenv

--- a/unittests/test_schema.py
+++ b/unittests/test_schema.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import pathlib
 from textwrap import dedent


### PR DESCRIPTION
At the very least, the test scripts should use `/usr/bin/env bash` so that they can be run on systems where `/bin/bash` doesn't exist. Also changes `/usr/bin/python3` to `/usr/bin/env python3`.

I'm unsure if we should leave the bwrap wrapper script and recipes.md files with `/bin/bash`? `/usr/bin/env bash` will work as well, but those are less critical to change.