### PR TITLE
Make test fixtures return each recipe separately

### DIFF
--- a/unittests/test_schema.py
+++ b/unittests/test_schema.py
@@ -20,19 +20,14 @@ def yaml_path(test_path):
     return test_path / "yaml"
 
 
-@pytest.fixture
-def recipes():
-    return [
-        "host-recipe",
-        "base-nvgpu",
-        "cache",
-        "with-repo",
-    ]
+@pytest.fixture(params=["host-recipe", "base-nvgpu", "cache", "with-repo"])
+def recipe(request):
+    return request.param
 
 
 @pytest.fixture
-def recipe_paths(test_path, recipes):
-    return [test_path / "recipes" / r for r in recipes]
+def recipe_path(test_path, recipe):
+    return test_path / "recipes" / recipe
 
 
 def test_config_yaml(yaml_path):
@@ -104,12 +99,11 @@ def test_config_yaml(yaml_path):
         schema.ConfigValidator.validate(raw)
 
 
-def test_recipe_config_yaml(recipe_paths):
+def test_recipe_config_yaml(recipe_path):
     # validate the config.yaml in the test recipes
-    for p in recipe_paths:
-        with open(p / "config.yaml") as fid:
-            raw = yaml.load(fid, Loader=yaml.Loader)
-            schema.ConfigValidator.validate(raw)
+    with open(recipe_path / "config.yaml") as fid:
+        raw = yaml.load(fid, Loader=yaml.Loader)
+        schema.ConfigValidator.validate(raw)
 
 
 def test_compilers_yaml(yaml_path):
@@ -128,12 +122,11 @@ def test_compilers_yaml(yaml_path):
         assert raw["nvhpc"] == {"version": "25.1"}
 
 
-def test_recipe_compilers_yaml(recipe_paths):
+def test_recipe_compilers_yaml(recipe_path):
     # validate the compilers.yaml in the test recipes
-    for p in recipe_paths:
-        with open(p / "compilers.yaml") as fid:
-            raw = yaml.load(fid, Loader=yaml.Loader)
-            schema.CompilersValidator.validate(raw)
+    with open(recipe_path / "compilers.yaml") as fid:
+        raw = yaml.load(fid, Loader=yaml.Loader)
+        schema.CompilersValidator.validate(raw)
 
 
 def test_environments_yaml(yaml_path):
@@ -189,12 +182,11 @@ def test_environments_yaml(yaml_path):
             schema.EnvironmentsValidator.validate(raw)
 
 
-def test_recipe_environments_yaml(recipe_paths):
+def test_recipe_environments_yaml(recipe_path):
     # validate the environments.yaml in the test recipes
-    for p in recipe_paths:
-        with open(p / "environments.yaml") as fid:
-            raw = yaml.load(fid, Loader=yaml.Loader)
-            schema.EnvironmentsValidator.validate(raw)
+    with open(recipe_path / "environments.yaml") as fid:
+        raw = yaml.load(fid, Loader=yaml.Loader)
+        schema.EnvironmentsValidator.validate(raw)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Makes each test parameterized over the recipe and easier to see which tests pass or fail. Each recipe becomes a separate test:
```
unittests/test_schema.py::test_config_yaml PASSED                                                                                                                                                                                  [  4%]
unittests/test_schema.py::test_recipe_config_yaml[host-recipe] PASSED                                                                                                                                                              [  8%]
unittests/test_schema.py::test_recipe_config_yaml[base-nvgpu] PASSED                                                                                                                                                               [ 13%]
unittests/test_schema.py::test_recipe_config_yaml[cache] PASSED                                                                                                                                                                    [ 17%]
unittests/test_schema.py::test_recipe_config_yaml[with-repo] PASSED                                                                                                                                                                [ 21%]
unittests/test_schema.py::test_recipe_config_yaml[with-multi-repos] PASSED                                                                                                                                                         [ 26%]
unittests/test_schema.py::test_compilers_yaml PASSED                                                                                                                                                                               [ 30%]
unittests/test_schema.py::test_recipe_compilers_yaml[host-recipe] PASSED                                                                                                                                                           [ 34%]
unittests/test_schema.py::test_recipe_compilers_yaml[base-nvgpu] PASSED                                                                                                                                                            [ 39%]
unittests/test_schema.py::test_recipe_compilers_yaml[cache] PASSED                                                                                                                                                                 [ 43%]
unittests/test_schema.py::test_recipe_compilers_yaml[with-repo] PASSED                                                                                                                                                             [ 47%]
unittests/test_schema.py::test_recipe_compilers_yaml[with-multi-repos] PASSED                                                                                                                                                      [ 52%]
```