### PR TITLE
Multiple package repos in config.yaml

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -30,4 +30,4 @@ jobs:
       working-directory: unittests
       run: |
         sudo apt-get install -y jq
-        ./test-envvars.sh
+        uv run bash ./test-envvars.sh

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,11 +23,11 @@ jobs:
         done
         exit $errors
     - name: Install Dependencies
-      run: uv sync --group dev
+      run: |
+        uv sync --group dev
+        sudo apt-get install -y jq
     - name: Run Unit Tests
       run: uv run pytest
     - name: Run Envvars Test
       working-directory: unittests
-      run: |
-        sudo apt-get install -y jq
-        uv run bash ./test-envvars.sh
+      run: uv run bash ./test-envvars.sh

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,3 +26,8 @@ jobs:
       run: uv sync --group dev
     - name: Run Unit Tests
       run: uv run pytest
+    - name: Run Envvars Test
+      working-directory: unittests
+      run: |
+        sudo apt-get install -y jq
+        ./test-envvars.sh

--- a/docs/cluster-config.md
+++ b/docs/cluster-config.md
@@ -129,8 +129,8 @@ If custom package definitions are provided for the same package in more than one
 
 The following precedence is applied, where 1 has higher precedence than 2 or 3:
 
-1. packages defined in the (optional) `repo` path in the [recipe](recipes.md#custom-spack-packages)
-2. packages defined in the (optional) site repo(s) defined in the `repo/repos.yaml` file of cluster configuration (documented here)
-3. packages provided by Spack (in the `var/spack/repos/builtin` path)
+1. packages defined in the (optional) `repo` path in the [recipe][custom-spack-packages]
+2. packages defined in the (optional) site repo(s) defined in the `repo/repos.yaml` file of the cluster configuration (documented here)
+3. packages defined in the package repositories configured in `config.yaml:spack:packages`, in the order specified (which typically includes `builtin`)
 
-As of Stackinator v4, the definitions of some custom repositories (mainly CSCS' custom cray-mpich and its dependencies) was removed from Stackinator, and moved to the the site configuration
+As of Stackinator v4, the definitions of some custom repositories (mainly CSCS' custom cray-mpich and its dependencies) was removed from Stackinator, and moved to the site configuration.

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -40,6 +40,37 @@ version: 2
 * `version`:  _default = 1_ the version of the uenv recipe (see below)
 * `modules`: (_deprecated_) _optional_ enable/disable module file generation.
 
+It's possible to configure multiple package repositories for the uenv build by providing a dictionary of spack repositories. For example:
+
+```yaml title="config.yaml"
+name: prgenv-gnu
+store: /user-environment
+spack:
+    repo: https://github.com/spack/spack.git
+    commit: releases/v1.0
+    packages:
+        builtin:
+            repo: https://github.com/spack/spack-packages.git
+            commit: develop
+        foo:
+            repo: https://github.com/foo/spack-packages.git
+            commit: v13.2
+            path: repos/spack_repo/foo
+version: 2
+```
+
+The `path` entry is optional and defaults to `repos/spack_repo/${name}`, where the dictionary key is the `name`.
+For the upstream spack-packages repository, the default value can be used.
+
+!!! info
+   The order of package repositories is significant.
+   stackinator follows the same semantics as spack itself, where package repositories further up in the list take precedence over ones later in the list.
+   Refer to the [spack documentation](https://spack.readthedocs.io/en/latest/repositories.html#search-order-and-overriding-packages) for more information.
+
+!!! info
+    `recipe` and `alps` are reserved repository names for internal stackinator use and can't be used for user-specified package repositories.
+    The `recipe` and `alps` repositories have higher precedence than repositories configured in `config.yaml` (see [custom spack packages][ref-custom-spack-packages] for more details).
+
 !!! note "uenv recipe versions"
     Stackinator 6 introduces breaking changes to the uenv recipe format, introduced to support Spack v1.0.
 
@@ -487,9 +518,10 @@ Modules are generated for the installed compilers and packages by spack.
     - `modules:default:arch_folder` defaults to `false`. If set to `true` an error is raised, as Stackinator does not support this feature;
     - `modules:default:roots:tcl` is ignored, as Stackinator automatically configures the module root to be inside the uenv mount point.
 
+[](){#ref-custom-spack-packages}
 ## Custom Spack Packages
 
-An optional package repository can be added to a recipe to provide new or customized Spack packages in addition to Spack's `builtin` package repository, if a `repo` path is provided in the recipe.
+An optional package repository can be added to a recipe to provide new or customized Spack packages in addition to the package repositories configured in `config.yaml`, if a `repo` path is provided in the recipe.
 
 For example, the following `repo` path will add custom package definitions for the `hdf5` and `nvhpc` packages:
 
@@ -501,6 +533,8 @@ repo
    └─ nvhpc
       └─ package.py
 ```
+
+Packages provided together with a recipe will be installed in a separate `recipe` namespace.
 
 Additional custom packages can be provided as part of the cluster configuration, as well as additional site packages.
 These packages are all optional, and will be installed together in a single Spack package repository that is made available to downstream users of the generated uenv stack.
@@ -523,12 +557,13 @@ See the documentation for [cluster configuration](cluster-config.md) for more de
     In the above case, the package `fmt` is backported from `origin/develop` into the `stackinator-recipe`.
 
 !!! alps
-    All packages are installed under a single spack package repository called `alps`.
+    All cluster configuration packages are installed under a single spack package repository called `alps`.
     The CSCS configurations in [github.com/eth-cscs/alps-cluster-config](https://github.com/eth-cscs/alps-cluster-config) provides a site configuration that defines cray-mpich, its dependencies, and the most up to date versions of cuda, nvhpc etc to all clusters on Alps.
+    These site packages are installed under the `alps` Spack package repository namespace.
 
 !!! warning
     Unlike Spack package repositories, any `repos.yaml` file in the `repo` path will be ignored.
-    This is because the provided packages are added to the `alps` namespace.
+    This is because the provided packages are installed in the `recipe` namespace.
 
 ## Post install configuration
 

--- a/stackinator/builder.py
+++ b/stackinator/builder.py
@@ -320,13 +320,11 @@ class Builder:
         # 2. cluster-config/repos.yaml
         #   - if the repos.yaml file exists it will contain a list of relative paths
         #     to search for package
-        # 1. builtin repo
+        # 1. package repos from config.yaml in the order specified (typically
+        #    only spack-packages builtin repo)
 
-        # Determine whether the recipe provides its own package repo
-        has_recipe_repo = recipe.spack_repo is not None
-
-        # Build a list of system repos with packages to install.
-        system_repos = []
+        # Build a list of repos with packages to install from system config and recipe.
+        repos = []
 
         # look for repos.yaml file in the system configuration
         repo_yaml = recipe.system_config_path / "repos.yaml"
@@ -342,13 +340,13 @@ class Builder:
             for rel_path in P:
                 repo_path = (recipe.system_config_path / rel_path).resolve()
                 if spack_util.is_repo(repo_path):
-                    system_repos.append(repo_path)
+                    repos.append(repo_path)
                     self._logger.debug(f"adding site spack package repo: {repo_path}")
                 else:
                     self._logger.error(f"{repo_path} from {repo_yaml} is not a spack package repository")
                     raise RuntimeError("invalid system-provided package repository")
 
-        self._logger.debug(f"full list of system spack package repos: {system_repos}")
+        self._logger.debug(f"full list of system spack package repos: {repos}")
 
         # Delete the store/repo path, if it already exists.
         # Do this so that incremental builds (though not officially supported) won't break if a repo is updated.
@@ -365,7 +363,7 @@ class Builder:
         self._logger.debug(f"created the repo packages path {pkg_dst}")
 
         # create the repository step 2: create the repo.yaml file that
-        # configures alps and builtin repos
+        # configures the alps repo
         with (repo_dst / "repo.yaml").open("w") as f:
             f.write(
                 """\
@@ -377,6 +375,7 @@ repo:
 
         # If the recipe provides a package repo, install it as a separate
         # "recipe" repo in the store with highest precedence.
+        has_recipe_repo = recipe.spack_repo is not None
         if has_recipe_repo:
             recipe_dst = repos_path / "recipe"
             self._logger.debug(f"creating the recipe spack repo in {recipe_dst}")
@@ -423,21 +422,22 @@ repo:
             )
             f.write("\n")
 
-        # Iterate over the system source repositories copying their contents to the
-        # consolidated alps repo in the uenv. Do not overwrite packages that have been
-        # copied from an earlier source repo, enforcing a descending order of precidence.
-        if len(system_repos) > 0:
-            for repo_src in system_repos:
-                self._logger.debug(f"installing repo {repo_src}")
-                packages_path = repo_src / "packages"
-                for pkg_path in packages_path.iterdir():
-                    dst = pkg_dst / pkg_path.name
-                    if pkg_path.is_dir() and not dst.exists():
-                        self._logger.debug(f"  installing package {pkg_path} to {pkg_dst}")
-                        install(pkg_path, dst)
-                    elif dst.exists():
-                        self._logger.debug(f"  NOT installing package {pkg_path}")
+        # Iterate over the alps and recipe repositories copying their contents
+        # to the final repo locations. Because of the order of repos in the
+        # repos.yaml config file, recipe packages have precedence.
+        for repo_src in repos:
+            self._logger.debug(f"installing repo {repo_src}")
+            packages_path = repo_src / "packages"
+            for pkg_path in packages_path.iterdir():
+                dst = pkg_dst / pkg_path.name
+                if pkg_path.is_dir() and not dst.exists():
+                    self._logger.debug(f"  installing package {pkg_path} to {pkg_dst}")
+                    install(pkg_path, dst)
+                elif dst.exists():
+                    self._logger.debug(f"  NOT installing package {pkg_path}")
 
+        # Copy all package repos defined in config.yaml to their final repo
+        # locations.
         for idx, pkg_meta in enumerate(spack_meta["packages"]):
             clone_path = pkg_meta["path"]
             name = pkg_meta["name"]

--- a/stackinator/builder.py
+++ b/stackinator/builder.py
@@ -199,9 +199,7 @@ class Builder:
 
         packages_meta = self._resolve_packages(spack["packages"])
         for pkg_repo in packages_meta:
-            pkg_repo["commit"] = self._git_clone(
-                pkg_repo["name"], pkg_repo["url"], pkg_repo["ref"], pkg_repo["path"]
-            )
+            pkg_repo["commit"] = self._git_clone(pkg_repo["name"], pkg_repo["url"], pkg_repo["ref"], pkg_repo["path"])
 
         spack_meta = {
             "url": spack_repo,

--- a/stackinator/builder.py
+++ b/stackinator/builder.py
@@ -197,8 +197,8 @@ class Builder:
 
         spack_git_commit_result = self._git_clone("spack", spack_repo, spack_commit, spack_path)
 
-        packages_meta = recipe.spack_package_repos
-        for pkg_repo in packages_meta:
+        package_repos = recipe.spack_package_repos
+        for pkg_repo in package_repos:
             pkg_repo["path"] = self.path / "repos" / pkg_repo["name"]
             pkg_repo["commit"] = self._git_clone(pkg_repo["name"], pkg_repo["url"], pkg_repo["ref"], pkg_repo["path"])
 
@@ -206,7 +206,7 @@ class Builder:
             "url": spack_repo,
             "ref": spack_commit,
             "commit": spack_git_commit_result,
-            "packages": packages_meta,
+            "packages": package_repos,
         }
 
         # load the jinja templating environment

--- a/stackinator/builder.py
+++ b/stackinator/builder.py
@@ -436,7 +436,7 @@ class Builder:
 
         # Copy all package repos defined in config.yaml to their final repo
         # locations.
-        for idx, pkg_repo in enumerate(spack_meta["packages"]):
+        for pkg_repo in spack_meta["packages"]:
             clone_path = pkg_repo["path"]
             name = pkg_repo["name"]
             src_path = clone_path / pkg_repo["repo_path"]

--- a/stackinator/builder.py
+++ b/stackinator/builder.py
@@ -197,8 +197,9 @@ class Builder:
 
         spack_git_commit_result = self._git_clone("spack", spack_repo, spack_commit, spack_path)
 
-        packages_meta = self._resolve_packages(spack["packages"])
+        packages_meta = recipe.spack_package_repos
         for pkg_repo in packages_meta:
+            pkg_repo["path"] = self.path / "repos" / pkg_repo["name"]
             pkg_repo["commit"] = self._git_clone(pkg_repo["name"], pkg_repo["url"], pkg_repo["ref"], pkg_repo["path"])
 
         spack_meta = {
@@ -544,29 +545,6 @@ class Builder:
                 )
             )
             f.write("\n")
-
-    def _resolve_packages(self, packages):
-        base = self.path / "repos"
-        if isinstance(packages.get("repo"), str):
-            return [
-                {
-                    "name": "builtin",
-                    "url": packages["repo"],
-                    "ref": packages.get("commit"),
-                    "path": base / "builtin",
-                    "repo_path": "repos/spack_repo/builtin",
-                }
-            ]
-        return [
-            {
-                "name": name,
-                "url": val["repo"],
-                "ref": val.get("commit"),
-                "path": base / name,
-                "repo_path": val.get("path", f"repos/spack_repo/{name}"),
-            }
-            for name, val in packages.items()
-        ]
 
     def _git_clone(self, name, repo, commit, path):
         if not (path / ".git").is_dir():

--- a/stackinator/builder.py
+++ b/stackinator/builder.py
@@ -196,7 +196,7 @@ class Builder:
         packages_resolved = self._resolve_packages(packages_config)
 
         packages_meta = []
-        for name, repo, commit in packages_resolved:
+        for name, repo, commit, repo_path in packages_resolved:
             clone_path = self.path / name
             git_commit_result = self._git_clone(name, repo, commit, clone_path)
             packages_meta.append({
@@ -205,6 +205,7 @@ class Builder:
                 "ref": commit,
                 "commit": git_commit_result,
                 "path": clone_path,
+                "repo_path": repo_path,
             })
 
         spack_meta = {
@@ -334,13 +335,11 @@ class Builder:
         #     to search for package
         # 1. builtin repo
 
-        # Build a list of repos with packages to install.
-        repos = []
+        # Determine whether the recipe provides its own package repo
+        has_recipe_repo = recipe.spack_repo is not None
 
-        # check for a repo in the recipe
-        if recipe.spack_repo is not None:
-            self._logger.debug(f"adding recipe spack package repo: {recipe.spack_repo}")
-            repos.append(recipe.spack_repo)
+        # Build a list of system repos with packages to install.
+        system_repos = []
 
         # look for repos.yaml file in the system configuration
         repo_yaml = recipe.system_config_path / "repos.yaml"
@@ -356,13 +355,13 @@ class Builder:
             for rel_path in P:
                 repo_path = (recipe.system_config_path / rel_path).resolve()
                 if spack_util.is_repo(repo_path):
-                    repos.append(repo_path)
+                    system_repos.append(repo_path)
                     self._logger.debug(f"adding site spack package repo: {repo_path}")
                 else:
                     self._logger.error(f"{repo_path} from {repo_yaml} is not a spack package repository")
                     raise RuntimeError("invalid system-provided package repository")
 
-        self._logger.debug(f"full list of spack package repo: {repos}")
+        self._logger.debug(f"full list of system spack package repos: {system_repos}")
 
         # Delete the store/repo path, if it already exists.
         # Do this so that incremental builds (though not officially supported) won't break if a repo is updated.
@@ -389,25 +388,56 @@ repo:
 """
             )
 
+        # If the recipe provides a package repo, install it as a separate
+        # "recipe" repo in the store with highest precedence.
+        if has_recipe_repo:
+            recipe_dst = repos_path / "recipe"
+            self._logger.debug(f"creating the recipe spack repo in {recipe_dst}")
+            if recipe_dst.exists():
+                self._logger.debug(f"{recipe_dst} exists ... deleting")
+                shutil.rmtree(recipe_dst)
+
+            recipe_pkg_dst = recipe_dst / "packages"
+            recipe_pkg_dst.mkdir(mode=0o755, parents=True)
+
+            with (recipe_dst / "repo.yaml").open("w") as f:
+                f.write(
+                    """\
+repo:
+  namespace: recipe
+  api: v2.0
+"""
+                )
+
+            packages_path = recipe.spack_repo / "packages"
+            for pkg_path in packages_path.iterdir():
+                dst = recipe_pkg_dst / pkg_path.name
+                if pkg_path.is_dir():
+                    self._logger.debug(f"  installing recipe package {pkg_path} to {recipe_pkg_dst}")
+                    install(pkg_path, dst)
+
         # create the repository step 2: create the repos.yaml file in build_path/config
         repos_yaml_template = jinja_env.get_template("repos.yaml")
         with (config_path / "repos.yaml").open("w") as f:
             repo_path = recipe.mount / "repos" / "spack_repo" / "alps"
             builtin_repo_path = recipe.mount / "repos" / "spack_repo" / "builtin"
+            recipe_repo_path = recipe.mount / "repos" / "spack_repo" / "recipe"
             f.write(
                 repos_yaml_template.render(
                     repo_path=repo_path.as_posix(),
                     builtin_repo_path=builtin_repo_path.as_posix(),
+                    recipe_repo_path=recipe_repo_path.as_posix(),
+                    has_recipe_repo=has_recipe_repo,
                     verbose=False,
                 )
             )
             f.write("\n")
 
-        # Iterate over the source repositories copying their contents to the consolidated repo in the uenv.
-        # Do overwrite packages that have been copied from an earlier source repo, enforcing a descending
-        # order of precidence.
-        if len(repos) > 0:
-            for repo_src in repos:
+        # Iterate over the system source repositories copying their contents to the
+        # consolidated alps repo in the uenv. Do not overwrite packages that have been
+        # copied from an earlier source repo, enforcing a descending order of precidence.
+        if len(system_repos) > 0:
+            for repo_src in system_repos:
                 self._logger.debug(f"installing repo {repo_src}")
                 packages_path = repo_src / "packages"
                 for pkg_path in packages_path.iterdir():
@@ -421,7 +451,7 @@ repo:
         for idx, pkg_meta in enumerate(spack_meta["packages"]):
             clone_path = pkg_meta["path"]
             name = pkg_meta["name"]
-            src_path = clone_path / "repos" / "spack_repo" / name
+            src_path = clone_path / pkg_meta["repo_path"]
             dst_path = store_path / "repos" / "spack_repo" / name
             self._logger.debug(f"copying repo \'{name}\' from {src_path} to {dst_path}")
             if dst_path.exists():
@@ -531,8 +561,8 @@ repo:
     @staticmethod
     def _resolve_packages(packages):
         if isinstance(packages.get("repo"), str):
-            return [("builtin", packages["repo"], packages.get("commit"))]
-        return [(name, val["repo"], val.get("commit")) for name, val in packages.items()]
+            return [("builtin", packages["repo"], packages.get("commit"), "repos/spack_repo/builtin")]
+        return [(name, val["repo"], val.get("commit"), val.get("path", f"repos/spack_repo/{name}")) for name, val in packages.items()]
 
     def _git_clone(self, name, repo, commit, path):
         if not (path / ".git").is_dir():

--- a/stackinator/builder.py
+++ b/stackinator/builder.py
@@ -198,8 +198,10 @@ class Builder:
         spack_git_commit_result = self._git_clone("spack", spack_repo, spack_commit, spack_path)
 
         packages_meta = self._resolve_packages(spack["packages"])
-        for pkg in packages_meta:
-            pkg["commit"] = self._git_clone(pkg["name"], pkg["url"], pkg["ref"], pkg["path"])
+        for pkg_repo in packages_meta:
+            pkg_repo["commit"] = self._git_clone(
+                pkg_repo["name"], pkg_repo["url"], pkg_repo["ref"], pkg_repo["path"]
+            )
 
         spack_meta = {
             "url": spack_repo,
@@ -403,10 +405,10 @@ class Builder:
             recipe_repo_path = recipe.mount / "repos" / "spack_repo" / "recipe"
             package_repos = [
                 {
-                    "name": pkg["name"],
-                    "path": (recipe.mount / "repos" / "spack_repo" / pkg["name"]).as_posix(),
+                    "name": pkg_repo["name"],
+                    "path": (recipe.mount / "repos" / "spack_repo" / pkg_repo["name"]).as_posix(),
                 }
-                for pkg in spack_meta["packages"]
+                for pkg_repo in spack_meta["packages"]
             ]
             f.write(
                 repos_yaml_template.render(

--- a/stackinator/builder.py
+++ b/stackinator/builder.py
@@ -408,7 +408,10 @@ repo:
             repo_path = recipe.mount / "repos" / "spack_repo" / "alps"
             recipe_repo_path = recipe.mount / "repos" / "spack_repo" / "recipe"
             package_repos = [
-                {"name": pkg["name"], "path": (recipe.mount / "repos" / "spack_repo" / pkg["name"]).as_posix()}
+                {
+                    "name": pkg["name"],
+                    "path": (recipe.mount / "repos" / "spack_repo" / pkg["name"]).as_posix(),
+                }
                 for pkg in spack_meta["packages"]
             ]
             f.write(
@@ -443,7 +446,7 @@ repo:
             name = pkg_meta["name"]
             src_path = clone_path / pkg_meta["repo_path"]
             dst_path = store_path / "repos" / "spack_repo" / name
-            self._logger.debug(f"copying repo \'{name}\' from {src_path} to {dst_path}")
+            self._logger.debug(f"copying repo '{name}' from {src_path} to {dst_path}")
             if dst_path.exists():
                 self._logger.debug(f"{dst_path} exists ... deleting")
                 shutil.rmtree(dst_path)
@@ -551,11 +554,25 @@ repo:
     def _resolve_packages(self, packages):
         base = self.path / "repos"
         if isinstance(packages.get("repo"), str):
-            return [{"name": "builtin", "url": packages["repo"], "ref": packages.get("commit"),
-                     "path": base / "builtin", "repo_path": "repos/spack_repo/builtin"}]
-        return [{"name": name, "url": val["repo"], "ref": val.get("commit"),
-                 "path": base / name, "repo_path": val.get("path", f"repos/spack_repo/{name}")}
-                for name, val in packages.items()]
+            return [
+                {
+                    "name": "builtin",
+                    "url": packages["repo"],
+                    "ref": packages.get("commit"),
+                    "path": base / "builtin",
+                    "repo_path": "repos/spack_repo/builtin",
+                }
+            ]
+        return [
+            {
+                "name": name,
+                "url": val["repo"],
+                "ref": val.get("commit"),
+                "path": base / name,
+                "repo_path": val.get("path", f"repos/spack_repo/{name}"),
+            }
+            for name, val in packages.items()
+        ]
 
     def _git_clone(self, name, repo, commit, path):
         if not (path / ".git").is_dir():

--- a/stackinator/builder.py
+++ b/stackinator/builder.py
@@ -437,10 +437,10 @@ class Builder:
 
         # Copy all package repos defined in config.yaml to their final repo
         # locations.
-        for idx, pkg_meta in enumerate(spack_meta["packages"]):
-            clone_path = pkg_meta["path"]
-            name = pkg_meta["name"]
-            src_path = clone_path / pkg_meta["repo_path"]
+        for idx, pkg_repo in enumerate(spack_meta["packages"]):
+            clone_path = pkg_repo["path"]
+            name = pkg_repo["name"]
+            src_path = clone_path / pkg_repo["repo_path"]
             dst_path = store_path / "repos" / "spack_repo" / name
             self._logger.debug(f"copying repo '{name}' from {src_path} to {dst_path}")
             if dst_path.exists():

--- a/stackinator/builder.py
+++ b/stackinator/builder.py
@@ -191,26 +191,27 @@ class Builder:
 
         spack_git_commit_result = self._git_clone("spack", spack_repo, spack_commit, spack_path)
 
-        # Clone the spack-packages repository and check out commit if one was given
-        spack_packages = spack["packages"]
-        spack_packages_repo = spack_packages["repo"]
-        spack_packages_commit = spack_packages["commit"]
-        spack_packages_path = self.path / "spack-packages"
+        # Clone the spack package repositories and check out commit if one was given
+        packages_config = spack["packages"]
+        packages_resolved = self._resolve_packages(packages_config)
 
-        spack_packages_git_commit_result = self._git_clone(
-            "spack-packages",
-            spack_packages_repo,
-            spack_packages_commit,
-            spack_packages_path,
-        )
+        packages_meta = []
+        for name, repo, commit in packages_resolved:
+            clone_path = self.path / name
+            git_commit_result = self._git_clone(name, repo, commit, clone_path)
+            packages_meta.append({
+                "name": name,
+                "url": repo,
+                "ref": commit,
+                "commit": git_commit_result,
+                "path": clone_path,
+            })
 
         spack_meta = {
             "url": spack_repo,
             "ref": spack_commit,
             "commit": spack_git_commit_result,
-            "packages_url": spack_packages_repo,
-            "packages_ref": spack_packages_commit,
-            "packages_commit": spack_packages_git_commit_result,
+            "packages": packages_meta,
         }
 
         # load the jinja templating environment
@@ -417,14 +418,16 @@ repo:
                     elif dst.exists():
                         self._logger.debug(f"  NOT installing package {pkg_path}")
 
-        # Copy the builtin repo to store, delete if it already exists.
-        spack_packages_builtin_path = spack_packages_path / "repos" / "spack_repo" / "builtin"
-        spack_packages_store_path = store_path / "repos" / "spack_repo" / "builtin"
-        self._logger.debug(f"copying builtin repo from {spack_packages_builtin_path} to {spack_packages_store_path}")
-        if spack_packages_store_path.exists():
-            self._logger.debug(f"{spack_packages_store_path} exists ... deleting")
-            shutil.rmtree(spack_packages_store_path)
-        install(spack_packages_builtin_path, spack_packages_store_path)
+        for idx, pkg_meta in enumerate(spack_meta["packages"]):
+            clone_path = pkg_meta["path"]
+            name = pkg_meta["name"]
+            src_path = clone_path / "repos" / "spack_repo" / name
+            dst_path = store_path / "repos" / "spack_repo" / name
+            self._logger.debug(f"copying repo \'{name}\' from {src_path} to {dst_path}")
+            if dst_path.exists():
+                self._logger.debug(f"{dst_path} exists ... deleting")
+                shutil.rmtree(dst_path)
+            install(src_path, dst_path)
 
         # Generate the makefile and spack.yaml files that describe the compilers
         compiler_files = recipe.compiler_files
@@ -524,6 +527,12 @@ repo:
                 )
             )
             f.write("\n")
+
+    @staticmethod
+    def _resolve_packages(packages):
+        if isinstance(packages.get("repo"), str):
+            return [("builtin", packages["repo"], packages.get("commit"))]
+        return [(name, val["repo"], val.get("commit")) for name, val in packages.items()]
 
     def _git_clone(self, name, repo, commit, path):
         if not (path / ".git").is_dir():

--- a/stackinator/builder.py
+++ b/stackinator/builder.py
@@ -197,7 +197,7 @@ class Builder:
 
         packages_meta = []
         for name, repo, commit, repo_path in packages_resolved:
-            clone_path = self.path / name
+            clone_path = self.path / "repos" / name
             git_commit_result = self._git_clone(name, repo, commit, clone_path)
             packages_meta.append({
                 "name": name,

--- a/stackinator/builder.py
+++ b/stackinator/builder.py
@@ -420,12 +420,15 @@ repo:
         repos_yaml_template = jinja_env.get_template("repos.yaml")
         with (config_path / "repos.yaml").open("w") as f:
             repo_path = recipe.mount / "repos" / "spack_repo" / "alps"
-            builtin_repo_path = recipe.mount / "repos" / "spack_repo" / "builtin"
             recipe_repo_path = recipe.mount / "repos" / "spack_repo" / "recipe"
+            package_repos = [
+                {"name": pkg["name"], "path": (recipe.mount / "repos" / "spack_repo" / pkg["name"]).as_posix()}
+                for pkg in spack_meta["packages"]
+            ]
             f.write(
                 repos_yaml_template.render(
                     repo_path=repo_path.as_posix(),
-                    builtin_repo_path=builtin_repo_path.as_posix(),
+                    package_repos=package_repos,
                     recipe_repo_path=recipe_repo_path.as_posix(),
                     has_recipe_repo=has_recipe_repo,
                     verbose=False,

--- a/stackinator/builder.py
+++ b/stackinator/builder.py
@@ -13,6 +13,12 @@ import yaml
 
 from . import VERSION, cache, root_logger, spack_util
 
+_REPO_YAML = """\
+repo:
+  namespace: {namespace}
+  api: v2.0
+"""
+
 
 def install(src, dst, *, ignore=None, symlinks=False):
     """Call shutil.copytree or shutil.copy2. copy2 is used if `src` is not a directory.
@@ -365,13 +371,7 @@ class Builder:
         # create the repository step 2: create the repo.yaml file that
         # configures the alps repo
         with (repo_dst / "repo.yaml").open("w") as f:
-            f.write(
-                """\
-repo:
-  namespace: alps
-  api: v2.0
-"""
-            )
+            f.write(_REPO_YAML.format(namespace="alps"))
 
         # If the recipe provides a package repo, install it as a separate
         # "recipe" repo in the store with highest precedence.
@@ -387,13 +387,7 @@ repo:
             recipe_pkg_dst.mkdir(mode=0o755, parents=True)
 
             with (recipe_dst / "repo.yaml").open("w") as f:
-                f.write(
-                    """\
-repo:
-  namespace: recipe
-  api: v2.0
-"""
-                )
+                f.write(_REPO_YAML.format(namespace="recipe"))
 
             packages_path = recipe.spack_repo / "packages"
             for pkg_path in packages_path.iterdir():

--- a/stackinator/builder.py
+++ b/stackinator/builder.py
@@ -191,22 +191,9 @@ class Builder:
 
         spack_git_commit_result = self._git_clone("spack", spack_repo, spack_commit, spack_path)
 
-        # Clone the spack package repositories and check out commit if one was given
-        packages_config = spack["packages"]
-        packages_resolved = self._resolve_packages(packages_config)
-
-        packages_meta = []
-        for name, repo, commit, repo_path in packages_resolved:
-            clone_path = self.path / "repos" / name
-            git_commit_result = self._git_clone(name, repo, commit, clone_path)
-            packages_meta.append({
-                "name": name,
-                "url": repo,
-                "ref": commit,
-                "commit": git_commit_result,
-                "path": clone_path,
-                "repo_path": repo_path,
-            })
+        packages_meta = self._resolve_packages(spack["packages"])
+        for pkg in packages_meta:
+            pkg["commit"] = self._git_clone(pkg["name"], pkg["url"], pkg["ref"], pkg["path"])
 
         spack_meta = {
             "url": spack_repo,
@@ -561,11 +548,14 @@ repo:
             )
             f.write("\n")
 
-    @staticmethod
-    def _resolve_packages(packages):
+    def _resolve_packages(self, packages):
+        base = self.path / "repos"
         if isinstance(packages.get("repo"), str):
-            return [("builtin", packages["repo"], packages.get("commit"), "repos/spack_repo/builtin")]
-        return [(name, val["repo"], val.get("commit"), val.get("path", f"repos/spack_repo/{name}")) for name, val in packages.items()]
+            return [{"name": "builtin", "url": packages["repo"], "ref": packages.get("commit"),
+                     "path": base / "builtin", "repo_path": "repos/spack_repo/builtin"}]
+        return [{"name": name, "url": val["repo"], "ref": val.get("commit"),
+                 "path": base / name, "repo_path": val.get("path", f"repos/spack_repo/{name}")}
+                for name, val in packages.items()]
 
     def _git_clone(self, name, repo, commit, path):
         if not (path / ".git").is_dir():

--- a/stackinator/etc/envvars.py
+++ b/stackinator/etc/envvars.py
@@ -694,7 +694,8 @@ if __name__ == "__main__":
     )
     uenv_parser.add_argument(
         "--spack-package-repo",
-        help='configure spack package repository metadata. Format is "name,spack_url,git_ref,git_commit". Can be repeated.',
+        help="configure spack package repository metadata. "
+        'Format is "name,spack_url,git_ref,git_commit". Can be repeated.',
         type=str,
         action="append",
         default=None,

--- a/stackinator/etc/envvars.py
+++ b/stackinator/etc/envvars.py
@@ -624,9 +624,31 @@ def meta_impl(args):
         spack_packages_url = None
         spack_packages_ref = None
         spack_packages_commit = None
-        if args.spack_packages is not None:
-            spack_packages_url, spack_packages_ref, spack_packages_commit = args.spack_packages.split(",")
+        package_repos = []
+        if args.spack_package_repo:
+            for entry in args.spack_package_repo:
+                parts = entry.split(",")
+                name, url, ref, commit = parts[0], parts[1], parts[2], parts[3]
+                package_repos.append({"name": name, "url": url, "ref": ref, "commit": commit})
+                if name == "builtin":
+                    spack_packages_url = url
+                    spack_packages_ref = ref
+                    spack_packages_commit = commit
         spack_path = f"{args.mount}/config".replace("//", "/")
+        scalar_vars = {
+            "UENV_SPACK_CONFIG_PATH": spack_path,
+            "UENV_SPACK_URL": spack_url,
+            "UENV_SPACK_REF": spack_ref,
+            "UENV_SPACK_COMMIT": spack_commit,
+            "UENV_SPACK_PACKAGES_URL": spack_packages_url,
+            "UENV_SPACK_PACKAGES_REF": spack_packages_ref,
+            "UENV_SPACK_PACKAGES_COMMIT": spack_packages_commit,
+        }
+        for repo in package_repos:
+            name_upper = repo["name"].upper().replace("-", "_")
+            scalar_vars[f"UENV_PACKAGE_REPO_{name_upper}_URL"] = repo["url"]
+            scalar_vars[f"UENV_PACKAGE_REPO_{name_upper}_REF"] = repo["ref"]
+            scalar_vars[f"UENV_PACKAGE_REPO_{name_upper}_COMMIT"] = repo["commit"]
         meta["views"]["spack"] = {
             "activate": "/dev/null",
             "description": "configure spack upstream",
@@ -636,15 +658,7 @@ def meta_impl(args):
                 "type": "augment",
                 "values": {
                     "list": {},
-                    "scalar": {
-                        "UENV_SPACK_CONFIG_PATH": spack_path,
-                        "UENV_SPACK_URL": spack_url,
-                        "UENV_SPACK_REF": spack_ref,
-                        "UENV_SPACK_COMMIT": spack_commit,
-                        "UENV_SPACK_PACKAGES_URL": spack_packages_url,
-                        "UENV_SPACK_PACKAGES_REF": spack_packages_ref,
-                        "UENV_SPACK_PACKAGES_COMMIT": spack_packages_commit,
-                    },
+                    "scalar": scalar_vars,
                 },
             },
         }
@@ -686,9 +700,10 @@ if __name__ == "__main__":
         default=None,
     )
     uenv_parser.add_argument(
-        "--spack-packages",
-        help='configure spack-packages repository metadata. Format is "spack_url,git_ref,git_commit"',
+        "--spack-package-repo",
+        help='configure spack package repository metadata. Format is "name,spack_url,git_ref,git_commit". Can be repeated.',
         type=str,
+        action="append",
         default=None,
     )
 

--- a/stackinator/etc/envvars.py
+++ b/stackinator/etc/envvars.py
@@ -621,34 +621,27 @@ def meta_impl(args):
 
     if args.spack is not None:
         spack_url, spack_ref, spack_commit = args.spack.split(",")
-        spack_packages_url = None
-        spack_packages_ref = None
-        spack_packages_commit = None
-        package_repos = []
-        if args.spack_package_repo:
-            for entry in args.spack_package_repo:
-                parts = entry.split(",")
-                name, url, ref, commit = parts[0], parts[1], parts[2], parts[3]
-                package_repos.append({"name": name, "url": url, "ref": ref, "commit": commit})
-                if name == "builtin":
-                    spack_packages_url = url
-                    spack_packages_ref = ref
-                    spack_packages_commit = commit
         spack_path = f"{args.mount}/config".replace("//", "/")
         scalar_vars = {
             "UENV_SPACK_CONFIG_PATH": spack_path,
             "UENV_SPACK_URL": spack_url,
             "UENV_SPACK_REF": spack_ref,
             "UENV_SPACK_COMMIT": spack_commit,
-            "UENV_SPACK_PACKAGES_URL": spack_packages_url,
-            "UENV_SPACK_PACKAGES_REF": spack_packages_ref,
-            "UENV_SPACK_PACKAGES_COMMIT": spack_packages_commit,
         }
-        for repo in package_repos:
-            name_upper = repo["name"].upper().replace("-", "_")
-            scalar_vars[f"UENV_PACKAGE_REPO_{name_upper}_URL"] = repo["url"]
-            scalar_vars[f"UENV_PACKAGE_REPO_{name_upper}_REF"] = repo["ref"]
-            scalar_vars[f"UENV_PACKAGE_REPO_{name_upper}_COMMIT"] = repo["commit"]
+        if args.spack_package_repo:
+            repo_names = []
+            for entry in args.spack_package_repo:
+                name, url, ref, commit = entry.split(",")
+                repo_names.append(name)
+                name_upper = name.upper().replace("-", "_")
+                scalar_vars[f"UENV_PACKAGE_REPO_{name_upper}_URL"] = url
+                scalar_vars[f"UENV_PACKAGE_REPO_{name_upper}_REF"] = ref
+                scalar_vars[f"UENV_PACKAGE_REPO_{name_upper}_COMMIT"] = commit
+                if name == "builtin":
+                    scalar_vars["UENV_SPACK_PACKAGES_URL"] = url
+                    scalar_vars["UENV_SPACK_PACKAGES_REF"] = ref
+                    scalar_vars["UENV_SPACK_PACKAGES_COMMIT"] = commit
+            scalar_vars["UENV_PACKAGE_REPOS"] = ",".join(repo_names)
         meta["views"]["spack"] = {
             "activate": "/dev/null",
             "description": "configure spack upstream",

--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -213,6 +213,8 @@ class Recipe:
             return repo_path
         return None
 
+    _RESERVED_REPO_NAMES = {"alps", "recipe"}
+
     @property
     def spack_package_repos(self):
         packages = self.config["spack"]["packages"]
@@ -225,7 +227,7 @@ class Recipe:
                     "repo_path": "repos/spack_repo/builtin",
                 }
             ]
-        return [
+        repos = [
             {
                 "name": name,
                 "url": val["repo"],
@@ -234,6 +236,15 @@ class Recipe:
             }
             for name, val in packages.items()
         ]
+        for repo in repos:
+            name = repo["name"]
+            if name in self._RESERVED_REPO_NAMES:
+                raise RuntimeError(
+                    f"The package repo name '{name}' is reserved for stackinator internal use. "
+                    f"Reserved names are: {self._RESERVED_REPO_NAMES}. "
+                    "Choose a different name in config.yaml:spack:packages."
+                )
+        return repos
 
     # Returns:
     #   Path: of the recipe extra path if it exists

--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -213,6 +213,28 @@ class Recipe:
             return repo_path
         return None
 
+    @property
+    def spack_package_repos(self):
+        packages = self.config["spack"]["packages"]
+        if isinstance(packages.get("repo"), str):
+            return [
+                {
+                    "name": "builtin",
+                    "url": packages["repo"],
+                    "ref": packages.get("commit"),
+                    "repo_path": "repos/spack_repo/builtin",
+                }
+            ]
+        return [
+            {
+                "name": name,
+                "url": val["repo"],
+                "ref": val.get("commit"),
+                "repo_path": val.get("path", f"repos/spack_repo/{name}"),
+            }
+            for name, val in packages.items()
+        ]
+
     # Returns:
     #   Path: of the recipe extra path if it exists
     #   None: if there is no user-provided extra path in the recipe

--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -224,7 +224,7 @@ class Recipe:
                     "name": "builtin",
                     "url": packages["repo"],
                     "ref": packages.get("commit"),
-                    "repo_path": "repos/spack_repo/builtin",
+                    "repo_path": packages.get("path", "repos/spack_repo/builtin"),
                 }
             ]
         repos = [

--- a/stackinator/schema/config.json
+++ b/stackinator/schema/config.json
@@ -4,6 +4,24 @@
     "type" : "object",
     "additionalProperties": false,
     "required": ["name", "spack"],
+    "defs": {
+        "repo_def": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["repo", "commit"],
+            "properties": {
+                "repo": {
+                    "type": "string"
+                },
+                "commit": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                }
+            }
+        }
+    },
     "properties" : {
         "name" : {
             "type": "string"
@@ -30,44 +48,17 @@
                 "packages": {
                     "oneOf": [
                         {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "required": ["repo"],
-                            "properties": {
-                                "repo": {
-                                    "type": "string"
-                                },
-                                "commit": {
-                                    "oneOf": [
-                                        {"type" : "string"},
-                                        {"type" : "null"}
-                                    ]
-                                }
-                            }
+                            "$ref": "#/defs/repo_def"
                         },
                         {
                             "type": "object",
                             "minProperties": 1,
-                            "additionalProperties": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "required": ["repo"],
-                                "properties": {
-                                    "repo": {
-                                        "type": "string"
-                                    },
-                                    "commit": {
-                                        "oneOf": [
-                                            {"type" : "string"},
-                                            {"type" : "null"}
-                                        ],
-                                        "default": null
-                                    },
-                                    "path": {
-                                        "type": "string"
-                                    }
+                            "patternProperties": {
+                                "^\\w[\\w-]*$": {
+                                    "$ref": "#/defs/repo_def"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
                     ]
                 }

--- a/stackinator/schema/config.json
+++ b/stackinator/schema/config.json
@@ -61,6 +61,9 @@
                                             {"type" : "string"},
                                             {"type" : "null"}
                                         ]
+                                    },
+                                    "path": {
+                                        "type": "string"
                                     }
                                 }
                             }

--- a/stackinator/schema/config.json
+++ b/stackinator/schema/config.json
@@ -28,21 +28,44 @@
                     "default": null
                 },
                 "packages": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "required": ["repo"],
-                    "properties" : {
-                        "repo": {
-                            "type": "string"
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": ["repo"],
+                            "properties": {
+                                "repo": {
+                                    "type": "string"
+                                },
+                                "commit": {
+                                    "oneOf": [
+                                        {"type" : "string"},
+                                        {"type" : "null"}
+                                    ]
+                                }
+                            }
                         },
-                        "commit": {
-                            "oneOf": [
-                                {"type" : "string"},
-                                {"type" : "null"}
-                            ],
-                            "default": null
+                        {
+                            "type": "object",
+                            "minProperties": 1,
+                            "additionalProperties": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "required": ["repo"],
+                                "properties": {
+                                    "repo": {
+                                        "type": "string"
+                                    },
+                                    "commit": {
+                                        "oneOf": [
+                                            {"type" : "string"},
+                                            {"type" : "null"}
+                                        ]
+                                    }
+                                }
+                            }
                         }
-                    }
+                    ]
                 }
             }
         },

--- a/stackinator/schema/config.json
+++ b/stackinator/schema/config.json
@@ -60,7 +60,8 @@
                                         "oneOf": [
                                             {"type" : "string"},
                                             {"type" : "null"}
-                                        ]
+                                        ],
+                                        "default": null
                                     },
                                     "path": {
                                         "type": "string"

--- a/stackinator/templates/Makefile
+++ b/stackinator/templates/Makefile
@@ -59,7 +59,7 @@ modules-done: environments generate-config
 
 env-meta: generate-config environments{% if modules %} modules-done{% endif %}
 
-	$(SANDBOX) $(BUILD_ROOT)/envvars.py uenv {% if modules %}--modules{% endif %} --spack='{{ spack_meta.url }},{{ spack_meta.ref }},{{ spack_meta.commit }}' --spack-packages='{{ spack_meta.packages_url }},{{ spack_meta.packages_ref }},{{ spack_meta.packages_commit }}' $(STORE)
+	$(SANDBOX) $(BUILD_ROOT)/envvars.py uenv {% if modules %}--modules{% endif %} --spack='{{ spack_meta.url }},{{ spack_meta.ref }},{{ spack_meta.commit }}'{% for pkg in spack_meta.packages %} --spack-package-repo='{{ pkg.name }},{{ pkg.url }},{{ pkg.ref }},{{ pkg.commit }}'{% endfor %} $(STORE)
 	touch env-meta
 
 post-install: env-meta

--- a/stackinator/templates/Makefile
+++ b/stackinator/templates/Makefile
@@ -59,7 +59,7 @@ modules-done: environments generate-config
 
 env-meta: generate-config environments{% if modules %} modules-done{% endif %}
 
-	$(SANDBOX) $(BUILD_ROOT)/envvars.py uenv {% if modules %}--modules{% endif %} --spack='{{ spack_meta.url }},{{ spack_meta.ref }},{{ spack_meta.commit }}'{% for pkg in spack_meta.packages %} --spack-package-repo='{{ pkg.name }},{{ pkg.url }},{{ pkg.ref }},{{ pkg.commit }}'{% endfor %} $(STORE)
+	$(SANDBOX) $(BUILD_ROOT)/envvars.py uenv {% if modules %}--modules{% endif %} --spack='{{ spack_meta.url }},{{ spack_meta.ref }},{{ spack_meta.commit }}'{% for pkg_repo in spack_meta.packages %} --spack-package-repo='{{ pkg_repo.name }},{{ pkg_repo.url }},{{ pkg_repo.ref }},{{ pkg_repo.commit }}'{% endfor %} $(STORE)
 	touch env-meta
 
 post-install: env-meta

--- a/stackinator/templates/repos.yaml
+++ b/stackinator/templates/repos.yaml
@@ -3,4 +3,6 @@ repos:
   recipe: {{ recipe_repo_path }}
 {% endif %}
   alps: {{ repo_path }}
-  builtin: {{ builtin_repo_path }}
+{% for repo in package_repos %}
+  {{ repo.name }}: {{ repo.path }}
+{% endfor %}

--- a/stackinator/templates/repos.yaml
+++ b/stackinator/templates/repos.yaml
@@ -1,3 +1,6 @@
 repos:
+{% if has_recipe_repo %}
+  recipe: {{ recipe_repo_path }}
+{% endif %}
   alps: {{ repo_path }}
   builtin: {{ builtin_repo_path }}

--- a/unittests/data/arbor-uenv/meta/env.json.in
+++ b/unittests/data/arbor-uenv/meta/env.json.in
@@ -9,11 +9,13 @@
     "arbor": {
       "activate": "@@mount@@/env/arbor/activate.sh",
       "description": "",
+      "recipe_variables": {"scalar": {}, "list": {}},
       "root": "@@mount@@/env/arbor"
     },
     "develop": {
       "activate": "@@mount@@/env/develop/activate.sh",
       "description": "",
+      "recipe_variables": {"scalar": {}, "list": {}},
       "root": "@@mount@@/env/develop"
     }
   }

--- a/unittests/recipes/base-nvgpu/config.yaml
+++ b/unittests/recipes/base-nvgpu/config.yaml
@@ -5,4 +5,5 @@ spack:
     commit: 6408b51
     packages:
         repo: https://github.com/spack/spack-packages.git
+        commit: 18b4066
 version: 2

--- a/unittests/recipes/cache/config.yaml
+++ b/unittests/recipes/cache/config.yaml
@@ -5,4 +5,5 @@ spack:
   commit: 6408b51
   packages:
     repo: https://github.com/spack/spack-packages.git
+    commit: 18b4066
 version: 2

--- a/unittests/recipes/host-recipe/config.yaml
+++ b/unittests/recipes/host-recipe/config.yaml
@@ -6,4 +6,5 @@ spack:
   repo: https://github.com/spack/spack.git
   packages:
     repo: https://github.com/spack/spack-packages.git
+    commit: releases/v0.23
 version: 2

--- a/unittests/recipes/with-multi-repos/compilers.yaml
+++ b/unittests/recipes/with-multi-repos/compilers.yaml
@@ -1,0 +1,2 @@
+gcc:
+  version: "11"

--- a/unittests/recipes/with-multi-repos/config.yaml
+++ b/unittests/recipes/with-multi-repos/config.yaml
@@ -1,0 +1,13 @@
+name: with-multi-repos
+store: '/user-environment'
+spack:
+    repo: https://github.com/spack/spack.git
+    commit: v21.0
+    packages:
+        my-packages:
+            repo: https://github.com/example/spack-packages.git
+            commit: v1.0
+            path: custom/path/to/packages
+        other-packages:
+            repo: https://github.com/example/other-packages.git
+version: 2

--- a/unittests/recipes/with-multi-repos/config.yaml
+++ b/unittests/recipes/with-multi-repos/config.yaml
@@ -10,4 +10,5 @@ spack:
             path: custom/path/to/packages
         other-packages:
             repo: https://github.com/example/other-packages.git
+            commit: v2.0
 version: 2

--- a/unittests/recipes/with-multi-repos/environments.yaml
+++ b/unittests/recipes/with-multi-repos/environments.yaml
@@ -1,0 +1,13 @@
+gcc-env:
+  compiler: [gcc]
+  unify: true
+  specs:
+  - osu-micro-benchmarks@5.9
+  - hdf5 +mpi
+  network:
+    mpi: cray-mpich
+tools:
+  compiler: [gcc]
+  unify: true
+  specs:
+  - cmake

--- a/unittests/recipes/with-repo/config.yaml
+++ b/unittests/recipes/with-repo/config.yaml
@@ -5,4 +5,5 @@ spack:
     commit: v21.0
     packages:
         repo: https://github.com/spack/spack-packages.git
+        commit: v21.0
 version: 2

--- a/unittests/test-envvars.sh
+++ b/unittests/test-envvars.sh
@@ -36,7 +36,7 @@ find $scratch_path -name env.json
 
 echo "===== running final meta data stage  ${mount_path}"
 
-../stackinator/etc/envvars.py uenv ${mount_path}/ --modules --spack="https://github.com/spack/spack.git,releases/v0.20" --spack-packages="https://github.com/spack/spack.git,develop"
+../stackinator/etc/envvars.py uenv ${mount_path}/ --modules --spack="https://github.com/spack/spack.git,releases/v0.20,abc123" --spack-package-repo="builtin,https://github.com/spack/spack-packages.git,develop,abc123"
 
 echo
 echo "===== develop"
@@ -57,4 +57,39 @@ echo
 echo "===== modules view"
 echo
 cat ${meta_path} | jq .views.modules
+
+echo
+echo "===== test UENV_PACKAGE_REPOS with multiple package repos"
+rm -rf ${mount_path}
+mkdir -p ${scratch_path}
+cp -R ${input_path} ${mount_path}
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    sed -i "s|@@mount@@|${mount_path}|g" ${meta_in_path}
+else
+    sed -i '' "s|@@mount@@|${mount_path}|g" ${meta_in_path}
+fi
+
+../stackinator/etc/envvars.py view ${mount_path}/env/arbor /dev/shm/bcumming/arbor
+../stackinator/etc/envvars.py view --prefix_paths="LD_LIBRARY_PATH=lib:lib64" ${mount_path}/env/develop /dev/shm/bcumming/arbor
+
+../stackinator/etc/envvars.py uenv ${mount_path}/ \
+    --spack="https://github.com/spack/spack.git,releases/v0.21,abc123def" \
+    --spack-package-repo="my-packages,https://github.com/example/spack-packages.git,v1.0,abc123" \
+    --spack-package-repo="other-packages,https://github.com/example/other-packages.git,main,def456"
+
+UENV_PACKAGE_REPOS=$(cat ${meta_path} | jq -r '.views.spack.env.values.scalar.UENV_PACKAGE_REPOS')
+echo "UENV_PACKAGE_REPOS=$UENV_PACKAGE_REPOS"
+if [[ "$UENV_PACKAGE_REPOS" != "my-packages,other-packages" ]]; then
+    echo "FAIL: expected my-packages,other-packages, got '${UENV_PACKAGE_REPOS}'"
+    exit 1
+fi
+
+UENV_PACKAGE_REPO_MY_PACKAGES_URL=$(cat ${meta_path} | jq -r '.views.spack.env.values.scalar.UENV_PACKAGE_REPO_MY_PACKAGES_URL')
+echo "UENV_PACKAGE_REPO_MY_PACKAGES_URL=$UENV_PACKAGE_REPO_MY_PACKAGES_URL"
+if [[ "$UENV_PACKAGE_REPO_MY_PACKAGES_URL" != "https://github.com/example/spack-packages.git" ]]; then
+    echo "FAIL: expected https://github.com/example/spack-packages.git, got '${UENV_PACKAGE_REPO_MY_PACKAGES_URL}'"
+    exit 1
+fi
+
+echo "PASSED"
 

--- a/unittests/test_schema.py
+++ b/unittests/test_schema.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import pathlib
 from textwrap import dedent
@@ -20,20 +20,14 @@ def yaml_path(test_path):
     return test_path / "yaml"
 
 
-@pytest.fixture
-def recipes():
-    return [
-        "host-recipe",
-        "base-nvgpu",
-        "cache",
-        "with-repo",
-        "with-multi-repos",
-    ]
+@pytest.fixture(params=["host-recipe", "base-nvgpu", "cache", "with-repo", "with-multi-repos"])
+def recipe(request):
+    return request.param
 
 
 @pytest.fixture
-def recipe_paths(test_path, recipes):
-    return [test_path / "recipes" / r for r in recipes]
+def recipe_path(test_path, recipe):
+    return test_path / "recipes" / recipe
 
 
 def test_config_yaml(yaml_path):
@@ -196,12 +190,11 @@ def test_config_yaml(yaml_path):
     assert "path" not in raw["spack"]["packages"]["my-packages"]
 
 
-def test_recipe_config_yaml(recipe_paths):
+def test_recipe_config_yaml(recipe_path):
     # validate the config.yaml in the test recipes
-    for p in recipe_paths:
-        with open(p / "config.yaml") as fid:
-            raw = yaml.load(fid, Loader=yaml.Loader)
-            schema.ConfigValidator.validate(raw)
+    with open(recipe_path / "config.yaml") as fid:
+        raw = yaml.load(fid, Loader=yaml.Loader)
+        schema.ConfigValidator.validate(raw)
 
 
 def test_compilers_yaml(yaml_path):
@@ -220,12 +213,11 @@ def test_compilers_yaml(yaml_path):
         assert raw["nvhpc"] == {"version": "25.1"}
 
 
-def test_recipe_compilers_yaml(recipe_paths):
+def test_recipe_compilers_yaml(recipe_path):
     # validate the compilers.yaml in the test recipes
-    for p in recipe_paths:
-        with open(p / "compilers.yaml") as fid:
-            raw = yaml.load(fid, Loader=yaml.Loader)
-            schema.CompilersValidator.validate(raw)
+    with open(recipe_path / "compilers.yaml") as fid:
+        raw = yaml.load(fid, Loader=yaml.Loader)
+        schema.CompilersValidator.validate(raw)
 
 
 def test_environments_yaml(yaml_path):
@@ -281,12 +273,11 @@ def test_environments_yaml(yaml_path):
             schema.EnvironmentsValidator.validate(raw)
 
 
-def test_recipe_environments_yaml(recipe_paths):
+def test_recipe_environments_yaml(recipe_path):
     # validate the environments.yaml in the test recipes
-    for p in recipe_paths:
-        with open(p / "environments.yaml") as fid:
-            raw = yaml.load(fid, Loader=yaml.Loader)
-            schema.EnvironmentsValidator.validate(raw)
+    with open(recipe_path / "environments.yaml") as fid:
+        raw = yaml.load(fid, Loader=yaml.Loader)
+        schema.EnvironmentsValidator.validate(raw)
 
 
 @pytest.mark.parametrize(

--- a/unittests/test_schema.py
+++ b/unittests/test_schema.py
@@ -165,6 +165,36 @@ def test_config_yaml(yaml_path):
         raw = yaml.load(config, Loader=yaml.Loader)
         schema.ConfigValidator.validate(raw)
 
+    # map format: custom path
+    config = dedent("""
+    version: 2
+    name: map-custom-path
+    spack:
+        repo: https://github.com/spack/spack.git
+        packages:
+            my-packages:
+                repo: https://github.com/example/spack-packages.git
+                path: custom/repo/location
+    """)
+    raw = yaml.load(config, Loader=yaml.Loader)
+    schema.ConfigValidator.validate(raw)
+    assert raw["spack"]["packages"]["my-packages"]["path"] == "custom/repo/location"
+
+    # map format: no path (default behavior)
+    config = dedent("""
+    version: 2
+    name: map-no-path
+    spack:
+        repo: https://github.com/spack/spack.git
+        packages:
+            my-packages:
+                repo: https://github.com/example/spack-packages.git
+                commit: v2.0
+    """)
+    raw = yaml.load(config, Loader=yaml.Loader)
+    schema.ConfigValidator.validate(raw)
+    assert "path" not in raw["spack"]["packages"]["my-packages"]
+
 
 def test_recipe_config_yaml(recipe_paths):
     # validate the config.yaml in the test recipes

--- a/unittests/test_schema.py
+++ b/unittests/test_schema.py
@@ -37,10 +37,9 @@ def test_config_yaml(yaml_path):
         schema.ConfigValidator.validate(raw)
         assert raw["store"] == "/user-environment"
         assert raw["spack"]["commit"] is None
-        assert raw["spack"]["packages"].get("commit") is None
         assert raw["description"] is None
 
-    # no spack:commit
+    # single repo format with packages commit
     config = dedent("""
     version: 2
     name: env-without-spack-commit
@@ -56,27 +55,22 @@ def test_config_yaml(yaml_path):
     )
     schema.ConfigValidator.validate(raw)
     assert raw["spack"]["commit"] is None
-    assert raw["spack"]["packages"]["commit"] is not None
+    assert raw["spack"]["packages"]["commit"] == "develop-packages"
     assert raw["description"] is None
 
-    # no spack:packages:commit
-    config = dedent("""
-    version: 2
-    name: env-without-spack-packages-commit
-    spack:
-        repo: https://github.com/spack/spack.git
-        commit: develop
-        packages:
+    # single repo format missing packages commit should fail
+    with pytest.raises(Exception):
+        config = dedent("""
+        version: 2
+        name: env-no-pkg-commit
+        spack:
             repo: https://github.com/spack/spack.git
-    """)
-    raw = yaml.load(
-        config,
-        Loader=yaml.Loader,
-    )
-    schema.ConfigValidator.validate(raw)
-    assert raw["spack"]["commit"] == "develop"
-    assert raw["spack"]["packages"].get("commit") is None
-    assert raw["description"] is None
+            commit: develop
+            packages:
+                repo: https://github.com/spack/spack.git
+        """)
+        raw = yaml.load(config, Loader=yaml.Loader)
+        schema.ConfigValidator.validate(raw)
 
     # full config
     with open(yaml_path / "config.full.yaml") as fid:
@@ -107,12 +101,13 @@ def test_config_yaml(yaml_path):
         packages:
             my-packages:
                 repo: https://github.com/example/spack-packages.git
+                commit: v1.0
     """)
     raw = yaml.load(config, Loader=yaml.Loader)
     schema.ConfigValidator.validate(raw)
     assert "my-packages" in raw["spack"]["packages"]
     assert raw["spack"]["packages"]["my-packages"]["repo"] == "https://github.com/example/spack-packages.git"
-    assert raw["spack"]["packages"]["my-packages"]["commit"] is None
+    assert raw["spack"]["packages"]["my-packages"]["commit"] == "v1.0"
 
     # map format: multiple entries with commits
     config = dedent("""
@@ -168,6 +163,7 @@ def test_config_yaml(yaml_path):
         packages:
             my-packages:
                 repo: https://github.com/example/spack-packages.git
+                commit: v1.0
                 path: custom/repo/location
     """)
     raw = yaml.load(config, Loader=yaml.Loader)

--- a/unittests/test_schema.py
+++ b/unittests/test_schema.py
@@ -112,7 +112,7 @@ def test_config_yaml(yaml_path):
     schema.ConfigValidator.validate(raw)
     assert "my-packages" in raw["spack"]["packages"]
     assert raw["spack"]["packages"]["my-packages"]["repo"] == "https://github.com/example/spack-packages.git"
-    assert raw["spack"]["packages"]["my-packages"].get("commit") is None
+    assert raw["spack"]["packages"]["my-packages"]["commit"] is None
 
     # map format: multiple entries with commits
     config = dedent("""

--- a/unittests/test_schema.py
+++ b/unittests/test_schema.py
@@ -27,6 +27,7 @@ def recipes():
         "base-nvgpu",
         "cache",
         "with-repo",
+        "with-multi-repos",
     ]
 
 
@@ -42,7 +43,7 @@ def test_config_yaml(yaml_path):
         schema.ConfigValidator.validate(raw)
         assert raw["store"] == "/user-environment"
         assert raw["spack"]["commit"] is None
-        assert raw["spack"]["packages"]["commit"] is None
+        assert raw["spack"]["packages"].get("commit") is None
         assert raw["description"] is None
 
     # no spack:commit
@@ -80,7 +81,7 @@ def test_config_yaml(yaml_path):
     )
     schema.ConfigValidator.validate(raw)
     assert raw["spack"]["commit"] == "develop"
-    assert raw["spack"]["packages"]["commit"] is None
+    assert raw["spack"]["packages"].get("commit") is None
     assert raw["description"] is None
 
     # full config
@@ -99,6 +100,67 @@ def test_config_yaml(yaml_path):
         name: cuda-env
         spack:
             repo: https://github.com/spack/spack.git
+        """)
+        raw = yaml.load(config, Loader=yaml.Loader)
+        schema.ConfigValidator.validate(raw)
+
+    # map format: single entry
+    config = dedent("""
+    version: 2
+    name: map-single
+    spack:
+        repo: https://github.com/spack/spack.git
+        packages:
+            my-packages:
+                repo: https://github.com/example/spack-packages.git
+    """)
+    raw = yaml.load(config, Loader=yaml.Loader)
+    schema.ConfigValidator.validate(raw)
+    assert "my-packages" in raw["spack"]["packages"]
+    assert raw["spack"]["packages"]["my-packages"]["repo"] == "https://github.com/example/spack-packages.git"
+    assert raw["spack"]["packages"]["my-packages"].get("commit") is None
+
+    # map format: multiple entries with commits
+    config = dedent("""
+    version: 2
+    name: map-multi
+    spack:
+        repo: https://github.com/spack/spack.git
+        packages:
+            my-packages:
+                repo: https://github.com/example/spack-packages.git
+                commit: v1.0
+            other-packages:
+                repo: https://github.com/example/other-packages.git
+                commit: v2.0
+    """)
+    raw = yaml.load(config, Loader=yaml.Loader)
+    schema.ConfigValidator.validate(raw)
+    assert raw["spack"]["packages"]["my-packages"]["commit"] == "v1.0"
+    assert raw["spack"]["packages"]["other-packages"]["commit"] == "v2.0"
+
+    # map format: empty map should fail
+    with pytest.raises(Exception):
+        config = dedent("""
+        version: 2
+        name: map-empty
+        spack:
+            repo: https://github.com/spack/spack.git
+            packages: {}
+        """)
+        raw = yaml.load(config, Loader=yaml.Loader)
+        schema.ConfigValidator.validate(raw)
+
+    # map format: entry missing repo should fail
+    with pytest.raises(Exception):
+        config = dedent("""
+        version: 2
+        name: map-no-repo
+        spack:
+            repo: https://github.com/spack/spack.git
+            packages:
+                my-packages:
+                    commit: v1.0
         """)
         raw = yaml.load(config, Loader=yaml.Loader)
         schema.ConfigValidator.validate(raw)

--- a/unittests/yaml/config.defaults.yaml
+++ b/unittests/yaml/config.defaults.yaml
@@ -7,7 +7,6 @@ spack:
     #commit: 6408b51
     packages:
         repo: https://github.com/spack/spack-packages.git
-        # default: None == no `git checkout` command
-        #commit: 6408b51
+        commit: 6408b51
 #modules: True
 version: 2


### PR DESCRIPTION
Extends config.yaml to accept not only
```yaml
...
    packages:
        repo: https://github.com/foo/spack-packages.git
        commit: abcdef
```
but also multiple repos:
```yaml
...
    packages:
        myrepo:
            repo: https://github.com/bar/other-packages.git
            commit: fedcba
            path: path/to/repo
        builtin:
            repo: https://github.com/foo/spack-packages.git
            commit: abcdef
```

Order of repos is significant in the same way it's significant in spack config files (https://spack.readthedocs.io/en/latest/repositories.html#search-order-and-overriding-packages). Packages from repos higher up on the list take precedence.

I made a small change so that there are also two implicit repos (currently on main there's one: `alps`). A repo `recipe` exists if and only if there are packages in the recipe. `alps` still exists, but doesn't have the recipe packages. The example above would produce the following list of repos:
- `recipe`
- `alps`
- `myrepo`
- `builtin`

Currently there's no enforcement that the repo entry has the same name as the repo namespace (similar to spack itself, if I understand it correctly). Is this ok?

There's an optional `path` property that can be used to point to a non-default subdirectory within the cloned git repo. For spack-packages this is always in `repos/spack_repo/builtin`, so the default is `repos/spack_repo/{name}`. In spack-packages there is an index file https://github.com/spack/spack-packages/blob/develop/spack-repo-index.yaml which _could_ be used to locate all the package repos within a git repo. Spack uses this when it clones package repos through git. For now I decided it's overkill to support that. Thoughts?