### PR TITLE
remove libs=static for mpc, gmp, mpfr, zstd, zlib

### DIFF
--- a/stackinator/templates/compilers.gcc.spack.yaml
+++ b/stackinator/templates/compilers.gcc.spack.yaml
@@ -13,13 +13,3 @@ spack:
   packages:
     gcc:
       variants: [build_type=Release +bootstrap +profiled +strip ~binutils]
-    mpc:
-      variants: [libs=static]
-    gmp:
-      variants: [libs=static]
-    mpfr:
-      variants: [libs=static]
-    zstd:
-      variants: [libs=static]
-    zlib:
-      variants: [~shared]


### PR DESCRIPTION
remove `libs=static` from bootstrap compiler dependencies.

Recently `depends_on('file')` has been added to `libtool`.
https://github.com/spack/spack-packages/blame/develop/repos/spack_repo/builtin/packages/libtool/package.py#L40

`file` chokes on `zstd libs=static` (missing `-fPIC` flag)