### PR TITLE
Add packages.yaml dependency for upstreams.yaml in Makefile

### DIFF
--- a/stackinator/templates/Makefile.generate-config
+++ b/stackinator/templates/Makefile.generate-config
@@ -13,7 +13,8 @@ COMPILER_PREFIXES ={% for compiler in release_compilers %} $$($(SPACK_HELPER) -e
 all: $(CONFIG_DIR)/upstreams.yaml $(CONFIG_DIR)/packages.yaml $(CONFIG_DIR)/repos.yaml{% if modules %} $(MODULE_DIR)/upstreams.yaml $(MODULE_DIR)/compilers.yaml{% endif %}
 
 # Generate the upstream configuration that will be provided by the mounted image
-$(CONFIG_DIR)/upstreams.yaml:
+# (requires packages.yaml to ensure that the path $(CONFIG_DIR) has been created).
+$(CONFIG_DIR)/upstreams.yaml: $(CONFIG_DIR)/packages.yaml
 	$(SPACK) config --scope=user add upstreams:system:install_tree:$(STORE)
 
 # Copy the cluster-specific packages.yaml file to the configuration.


### PR DESCRIPTION
The `all` target executes upstreams.yaml dependency first but it does not ensure that $(CONFIG_DIR) exists.  This fix is required for successful execution on Rocky 10 using Spack v1.1.0.