### PR TITLE
Do not rebuild build cache index every time we push

### DIFF
--- a/stackinator/templates/Makefile
+++ b/stackinator/templates/Makefile
@@ -84,7 +84,7 @@ cache-force: mirror-setup
 	$(warning likely have to start a fresh build (but that's okay, because build caches FTW))
 	$(warning ================================================================================)
 	$(SANDBOX) $(MAKE) -C generate-config
-	$(SANDBOX) $(SPACK) --color=never -C $(STORE)/config buildcache create --rebuild-index --only=package alpscache \
+	$(SANDBOX) $(SPACK) --color=never -C $(STORE)/config buildcache create --only=package alpscache \
 	$$($(SANDBOX) $(SPACK_HELPER) -C $(STORE)/config find --format '{name};{/hash};version={version}' \
 	| grep -v -E '^({% for p in exclude_from_cache %}{{ pipejoiner() }}{{ p }}{% endfor %});'\
 	| grep -v -E 'version=git\.'\

--- a/stackinator/templates/Makefile.compilers
+++ b/stackinator/templates/Makefile.compilers
@@ -19,7 +19,7 @@ all:{% for compiler in compilers %} {{ compiler }}/generated/build_cache{% endfo
 {% for compiler, config in compilers.items() %}
 {{ compiler }}/generated/build_cache: {{ compiler }}/generated/env
 {% if push_to_cache %}
-	$(SPACK) -e ./{{ compiler }} buildcache create --rebuild-index --only=package alpscache \
+	$(SPACK) -e ./{{ compiler }} buildcache create --only=package alpscache \
 	$$($(SPACK_HELPER) -e ./{{ compiler }} find --format '{name};{/hash}' \
 	| grep -v -E '^({% for p in config.exclude_from_cache %}{{ pipejoiner() }}{{ p }}{% endfor %});'\
 	| cut -d ';' -f2)

--- a/stackinator/templates/Makefile.environments
+++ b/stackinator/templates/Makefile.environments
@@ -18,7 +18,7 @@ all:{% for env in environments %} {{ env }}/generated/build_cache{% endfor %}
 {% for env, config in environments.items() %}
 {{ env }}/generated/build_cache: {{ env }}/generated/view_config
 {% if push_to_cache %}
-	$(SPACK) --color=never -e ./{{ env }} buildcache create --rebuild-index --only=package alpscache \
+	$(SPACK) --color=never -e ./{{ env }} buildcache create --only=package alpscache \
 	$$($(SPACK_HELPER) -e ./{{ env }} find --format '{name};{/hash};version={version}' \
 	| grep -v -E '^({% for p in config.exclude_from_cache %}{{ pipejoiner() }}{{ p }}{% endfor %});'\
 	| grep -v -E 'version=git\.'\


### PR DESCRIPTION
* rebuilding the index is expensive: scaling linearly with the number of packages in the build cache
* it is not required for concretizer:reuse:false, which is the default mode of operation for stackinator