### PR TITLE
fix: Add capabilities for stackinator to utilize LMOD modules.

### DIFF
--- a/stackinator/builder.py
+++ b/stackinator/builder.py
@@ -220,11 +220,18 @@ class Builder:
         # generate top level makefiles
         makefile_template = jinja_env.get_template("Makefile")
 
+        # Extract module types that were configured in recipe.py
+        module_types = []
+        if recipe.with_modules and recipe.modules:
+            roots = recipe.modules.get("modules", {}).get("default", {}).get("roots", {})
+            module_types = list(roots.keys())
+
         with (self.path / "Makefile").open("w") as f:
             f.write(
                 makefile_template.render(
                     cache=recipe.mirror,
                     modules=recipe.with_modules,
+                    module_types=module_types,
                     post_install_hook=recipe.post_install_hook,
                     pre_install_hook=recipe.pre_install_hook,
                     spack_version=spack_version,

--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -74,9 +74,22 @@ class Recipe:
                 # Note:
                 # modules root should match MODULEPATH set by envvars and used by uenv view "modules"
                 # so we enforce that the user does not override it in modules.yaml
-                self.modules["modules"].setdefault("default", {}).setdefault("roots", {}).setdefault(
-                    "tcl", (self.mount / "modules").as_posix()
-                )
+
+                # Spack supports these module types (as of Spack 1.0+)
+                VALID_MODULE_TYPES = {"tcl", "lmod"}
+
+                # Update the root path for each module type that the user configured
+                # This respects the user's choice of tcl, lmod, or both
+                defaults = self.modules["modules"].setdefault("default", {})
+                roots = defaults.setdefault("roots", {})
+
+                for module_type in list(roots.keys()):
+                    if module_type not in VALID_MODULE_TYPES:
+                        raise ValueError(
+                            f"Invalid module type '{module_type}' in modules.yaml. "
+                            f"Supported types: {', '.join(sorted(VALID_MODULE_TYPES))}"
+                        )
+                    roots[module_type] = (self.mount / "modules").as_posix()
 
         # DEPRECATED field `config:modules`
         if "modules" in self.config:

--- a/stackinator/recipe.py
+++ b/stackinator/recipe.py
@@ -83,7 +83,23 @@ class Recipe:
                 defaults = self.modules["modules"].setdefault("default", {})
                 roots = defaults.setdefault("roots", {})
 
-                for module_type in list(roots.keys()):
+                # Determine which module types to configure
+                # Priority: 1) explicit roots:, 2) enable: list, 3) default to tcl
+                if not roots:
+                    # No explicit roots configured, check enable: list
+                    enabled = defaults.get("enable", [])
+                    if enabled:
+                        # Use the enabled module types
+                        module_types = enabled
+                    else:
+                        # No enable list either, default to tcl for backward compatibility
+                        module_types = ["tcl"]
+                else:
+                    # Use explicitly configured roots
+                    module_types = list(roots.keys())
+
+                # Set the root path for each module type
+                for module_type in module_types:
                     if module_type not in VALID_MODULE_TYPES:
                         raise ValueError(
                             f"Invalid module type '{module_type}' in modules.yaml. "

--- a/stackinator/templates/Makefile
+++ b/stackinator/templates/Makefile
@@ -52,7 +52,9 @@ environments: compilers
 
 {% if modules %}
 modules-done: environments generate-config
-	$(SANDBOX) $(SPACK) -C $(BUILD_ROOT)/modules module tcl refresh --upstream-modules --delete-tree --yes-to-all
+	{% for module_type in module_types %}
+	$(SANDBOX) $(SPACK) -C $(BUILD_ROOT)/modules module {{ module_type }} refresh --upstream-modules --delete-tree --yes-to-all
+	{% endfor %}
 	touch modules-done
 {% endif %}
 


### PR DESCRIPTION
Previously, stackinator did not have the capability to utilize an LMOD module structure and defaulted to TCL. This will allow both to be utilized via an update to the Makefile template.